### PR TITLE
[Feature] catalogues improvements

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -75,6 +75,7 @@ const StyledButton = styled.button<IButtonStyleProps>`
       overflow: hidden;
       white-space: nowrap;
       transition: all .3s ease-in-out;
+      vertical-align: middle;
     }
 
     &:hover, &:focus {
@@ -84,7 +85,6 @@ const StyledButton = styled.button<IButtonStyleProps>`
 
       .text {
         max-width: 150px;
-        white-space: auto;
       }
     }
   `}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { SerializedStyles, css } from '@emotion/core';
 
 enum EButtonType {
   submit = 'submit',
@@ -15,10 +16,12 @@ interface IButtonProps {
   testId?: string;
   onClick?: (event: React.MouseEvent) => void;
   disabled?: boolean;
+  isExpanding?: boolean;
 }
 
 interface IButtonStyleProps {
   ghost?: boolean;
+  isExpanding?: boolean;
 }
 
 const StyledButton = styled.button<IButtonStyleProps>`
@@ -59,11 +62,41 @@ const StyledButton = styled.button<IButtonStyleProps>`
     margin-right: .5rem;
     fill: #FFF;
   }
+
+  ${(props): SerializedStyles => props.isExpanding && css`
+  .button-icon {
+      margin-right: 0;
+    }
+
+    .text {
+      display: inline-block;
+      width: auto;
+      max-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      transition: all .3s ease-in-out;
+    }
+
+    &:hover, &:focus {
+      .button-icon {
+        margin-right: .5rem;
+      }
+
+      .text {
+        max-width: 150px;
+        white-space: auto;
+      }
+    }
+  `}
 `;
 
-export const Button: React.FC<IButtonProps> = ({ className, icon: Icon, children, ghost, onClick, type = 'button', testId = '', disabled }) => {
+export const Button: React.FC<IButtonProps> = ({ className, icon: Icon, children, ghost, onClick, type = 'button', testId = '', disabled, isExpanding }) => {
+  if (isExpanding && !Icon) {
+    throw new Error('To have an expanding button you need an icon');
+  }
+
   return (
-    <StyledButton ghost={ghost} onClick={onClick} type={type} className={className} data-testid={testId} disabled={disabled}>
+    <StyledButton ghost={ghost} onClick={onClick} type={type} className={className} data-testid={testId} disabled={disabled} isExpanding={isExpanding}>
       <span className="button">
         {Icon && <Icon className="button-icon" />}
         <span className="text">{children}</span>

--- a/src/components/catalogues-archive/catalogues-archive.tsx
+++ b/src/components/catalogues-archive/catalogues-archive.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FileSystem } from '../file-system';
 import { useCatalogues } from '../../shared/hooks/useCatalogues';
+import { Loader } from '../loader';
 
 export const CataloguesArchive: React.FC = () => {
 	const filesystem = useCatalogues();
@@ -9,7 +10,7 @@ export const CataloguesArchive: React.FC = () => {
 
 	return (
 		isLoading ? (
-			<div>Loading</div>
+			<Loader />
 		) : (
 			<FileSystem {...filesystem} />
 		)

--- a/src/components/confirm-delete/confirm-delete.tsx
+++ b/src/components/confirm-delete/confirm-delete.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import { Button } from '../button';
+import { WarningIcon } from '../icons/Icon';
+
+interface IConfirmDeleteProps {
+	onConfirm: () => void;
+	onCancel: () => void;
+	warningMessage?: string;
+	list: string[];
+}
+
+const StyledDiv = styled.div`
+	padding: .5rem 0;
+
+	ul {
+    list-style: initial;
+    margin-top: .5rem;
+    margin-bottom: 1rem;
+    padding-inline-start: 1.5rem;
+	}
+
+	.warning {
+    display: flex;
+		background: #ffedb9;
+		padding: 1rem;
+		margin-bottom: 1rem;
+
+		svg {
+			margin-right: .5rem;
+			color: #F13C20;
+		}
+	}
+
+	.buttons-container {
+		display: flex;
+		justify-content: flex-end;
+
+		button:not(:last-of-type) {
+			margin-right: .5rem;
+		}
+	}
+`;
+
+export const ConfirmDelete: React.FC<IConfirmDeleteProps> = ({ onConfirm, onCancel, list, warningMessage }) => {
+	return (
+		<StyledDiv>
+			<ul>
+				{list.map(entry => <li key={entry}>{entry}</li>)}
+			</ul>
+			{warningMessage && (
+				<div className="warning">
+					<WarningIcon />
+					<p>{warningMessage}</p>
+				</div>
+			)}
+			<div className="buttons-container">
+				<Button onClick={onCancel}>
+					Annulla
+				</Button>
+				<Button onClick={onConfirm} ghost>
+					Conferma
+				</Button>
+			</div>
+		</StyledDiv>
+	);
+}

--- a/src/components/confirm-delete/index.ts
+++ b/src/components/confirm-delete/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmDelete } from './confirm-delete';

--- a/src/components/file-system/file-list.tsx
+++ b/src/components/file-system/file-list.tsx
@@ -32,8 +32,8 @@ const StyledDivContainer = styled.div`
 	}
 `;
 
-const StyledTableContainer = styled.div`
-	> div {
+const StyledTableContainer = styled.table`
+	tr {
 		position: relative;
 		padding: .5rem;
 
@@ -68,6 +68,38 @@ export const FileList: React.FC<IFileListProps> = ({ view, files, viewFile, clas
 	
 	const Container = containerMap[view];
 
+	if (view === 'table') {
+		return (
+			<Container className={className}>
+				<thead>
+					<tr>
+						<th>
+							Nome
+						</th>
+						<th>
+							Data
+						</th>
+						<th>
+							Dimensione
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{files.map(
+						(file) => 
+							<File
+								key={file.id}
+								file={file}
+								viewFile={viewFile}
+								view={view}
+							/>
+						)
+					}
+				</tbody>
+			</Container>
+		);
+	}
+
 	return (
 		<Container className={className}>
 			{files.map(
@@ -76,6 +108,7 @@ export const FileList: React.FC<IFileListProps> = ({ view, files, viewFile, clas
 						key={file.id}
 						file={file}
 						viewFile={viewFile}
+						view={view}
 					/>
 				)
 			}

--- a/src/components/file-system/file-list.tsx
+++ b/src/components/file-system/file-list.tsx
@@ -41,7 +41,7 @@ const StyledTableContainer = styled.div`
 
 	th {
 		padding: .5rem;
-		border-bottom: 1px solid #d3deed;
+		border-bottom: 1px solid #98a4b5;
 		text-align: left;
 		font-weight: bold;
 	}

--- a/src/components/file-system/file-list.tsx
+++ b/src/components/file-system/file-list.tsx
@@ -9,6 +9,7 @@ interface IFileListProps {
 	files: (IFile | IEnrichedFile)[];
 	viewFile: (file: IFile | IEnrichedFile) => void;
 	view: IView;
+	className?: string;
 }
 
 const StyledDivContainer = styled.div`
@@ -60,7 +61,7 @@ const containerMap = {
 	grid: StyledDivContainer,
 }
 
-export const FileList: React.FC<IFileListProps> = ({ view, files, viewFile }) => {
+export const FileList: React.FC<IFileListProps> = ({ view, files, viewFile, className}) => {
 	if (files.length === 0) {
 		return <p>Non ci sono file qui</p>;
 	}
@@ -68,7 +69,7 @@ export const FileList: React.FC<IFileListProps> = ({ view, files, viewFile }) =>
 	const Container = containerMap[view];
 
 	return (
-		<Container>
+		<Container className={className}>
 			{files.map(
 				(file) => 
 					<File

--- a/src/components/file-system/file-list.tsx
+++ b/src/components/file-system/file-list.tsx
@@ -4,6 +4,8 @@ import { File } from './file';
 import { IFile } from '../../services/firebase/db';
 import { IEnrichedFile } from '../../utils/file-system';
 import styled from '@emotion/styled';
+import { CheckboxCheckedIcon } from '../icons/Icon';
+import { HiddenContent } from '../hidden-content/hidden-content';
 
 interface IFileListProps {
 	files: (IFile | IEnrichedFile)[];
@@ -32,25 +34,16 @@ const StyledDivContainer = styled.div`
 	}
 `;
 
-const StyledTableContainer = styled.table`
-	tr {
-		position: relative;
-		padding: .5rem;
-
-		&:nth-of-type(even) {
-			background-color: rgba(0,0,0,.25);
-		}
-	}
-
-	button {
+const StyledTableContainer = styled.div`
+	table {
 		width: 100%;
-		text-align: left;
-		font-size: 1rem;
 	}
 
-	svg {
-		margin-right: .5rem;
-		font-size: 1rem;
+	th {
+		padding: .5rem;
+		border-bottom: 1px solid #d3deed;
+		text-align: left;
+		font-weight: bold;
 	}
 `;
 
@@ -71,31 +64,37 @@ export const FileList: React.FC<IFileListProps> = ({ view, files, viewFile, clas
 	if (view === 'table') {
 		return (
 			<Container className={className}>
-				<thead>
-					<tr>
-						<th>
-							Nome
-						</th>
-						<th>
-							Data
-						</th>
-						<th>
-							Dimensione
-						</th>
-					</tr>
-				</thead>
-				<tbody>
-					{files.map(
-						(file) => 
-							<File
-								key={file.id}
-								file={file}
-								viewFile={viewFile}
-								view={view}
-							/>
-						)
-					}
-				</tbody>
+				<table>
+					<thead>
+						<tr>
+							<th>
+								<CheckboxCheckedIcon aria-hidden />
+								<HiddenContent>Selezionato</HiddenContent>
+							</th>
+							<th>
+								Nome
+							</th>
+							<th>
+								Data
+							</th>
+							<th>
+								Dimensione
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{files.map(
+							(file) => 
+								<File
+									key={file.id}
+									file={file}
+									viewFile={viewFile}
+									view={view}
+								/>
+							)
+						}
+					</tbody>
+				</table>
 			</Container>
 		);
 	}

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -116,15 +116,10 @@ export const useCatalogueUtilities = (): ICataloguesContext => useContext(Catalo
 export const useSelected = (): ISelectedContext => useContext(SelectedContext);
 
 export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, categoriesLookup, filesList }) => {
-	const { isInternal, apiUrl } = useConfig();
+	const { isInternal } = useConfig();
 	const [currentFolders, setCurrentFolders] = useState<ICurrentFolder[]>([]);
 	const [selectedFiles, setSelectedFiles] = useState<(IFile | IEnrichedFile)[]>([]);
 	const [shownFile, setShownFile] = useState<IFile | IEnrichedFile>();
-	const shownUrl = shownFile ?
-		isInternal ?
-			`${apiUrl}/file/${shownFile.filename}` :
-			shownFile.storeUrl :
-		'';
 	const resetShownFile = (): void => setShownFile(null);
 
 	const [isEditing, setIsEditing] = useState(false);
@@ -285,7 +280,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 							<FileList files={shownFiles} viewFile={setShownFile} view={view} />
 						</div>
 					</StyledContainer>
-					{shownFile && <PdfViewer url={shownUrl} closeModal={resetShownFile} />}
+					{shownFile && <PdfViewer file={shownFile} closeModal={resetShownFile} />}
 					{selectedFiles.length !== 0 && (
 						<Modal isOpen={isEditing} closeModal={finishEditing} className="modal-small">
 							{selectedFiles.length > 1 ? (

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -16,7 +16,7 @@ import { CataloguesForm, UploadCataloguesForm } from '../forms/catalogues-form';
 import { MultiCataloguesForm } from '../forms/catalogues-form/multi-catalogues-form';
 import { Checkbox } from '../inputs/checkbox';
 import { Button } from '../button';
-import { GridIcon, ListIcon, Pencil, SearchIcon, SyncIcon, Trash, UploadIcon } from '../icons/Icon';
+import { GridIcon, ListIcon, MenuIcon, Pencil, SearchIcon, SyncIcon, Trash, UploadIcon } from '../icons/Icon';
 import { FileList, IView } from './file-list';
 import { CataloguesApiService } from '../../services/catalogues-api';
 import { ConfirmDelete } from '../confirm-delete';
@@ -27,6 +27,7 @@ const StyledContainer = styled.div`
 	margin: 2rem auto;
 	max-width: 1600px;
 	background: #fff;
+	overflow: hidden;
 
 	.header {
 		display: flex;
@@ -143,6 +144,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 	const [view, setView] = useState<IView>(() => {
 		return (localStorage.getItem('file-view') as IView) || 'table';
 	});
+	const [isQueueOpen, setIsQueueOpen] = useState(false);
 
 	const { isSearching, onSearch, results } = useSearch(filesList, {
 			includeScore: false,
@@ -274,7 +276,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 		<CurrentFolderContext.Provider value={{currentFolders, setCurrentFolder, toggleSelectedFolders}}>
 			<CataloguesContext.Provider value={{categoriesLookup}}>
 				<SelectedContext.Provider value={{ files: selectedFiles, selectFile: toggleSelectedFile, startEditing }}>
-					{queue.current && <QueueVisualiser queue={queue.current} />}
+					{queue.current && <QueueVisualiser queue={queue.current} isOpen={isQueueOpen} close={(): void => setIsQueueOpen(false)} />}
 					<StyledContainer>
 						<div className="header">
 							<div className="current-folder">
@@ -293,6 +295,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 									<Button onClick={toggleView} ghost icon={view === 'grid' ? ListIcon : GridIcon} isExpanding>
 										{view === 'grid' ? 'Tabella' : 'Griglia'}
 									</Button>
+									<Button onClick={(): void => setIsQueueOpen(!isQueueOpen)} icon={MenuIcon} isExpanding>Coda</Button>
 							</div>
 						</div>
 						<div className="filesystem-container">

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -195,7 +195,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 		setIsSyncing(true);
 
 		const callId = await CataloguesApiService.sync();
-		queue.current.push({ id: callId, label: 'sync', type: 'sync' });
+		queue.current.push({ id: callId, label: 'Sincronizzazione', type: 'sync' });
 
 		CataloguesApiService.pollSyncStatus(callId, (status) => queue.current?.update?.(callId, status));
 		setIsSyncing(false);
@@ -295,7 +295,12 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 									<Button onClick={toggleView} ghost icon={view === 'grid' ? ListIcon : GridIcon} isExpanding>
 										{view === 'grid' ? 'Tabella' : 'Griglia'}
 									</Button>
-									<Button onClick={(): void => setIsQueueOpen(!isQueueOpen)} icon={MenuIcon} isExpanding>Coda</Button>
+									<Button
+										onClick={(): void => setIsQueueOpen(!isQueueOpen)}
+										icon={MenuIcon}
+									>
+										{`Coda (${Object.keys(queue.current?.queue || {}).length})`}
+									</Button>
 							</div>
 						</div>
 						<div className="filesystem-container">
@@ -343,6 +348,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 								<UploadCataloguesForm
 									selectedCategory={currentFolders.length === 1 ? currentFolders[0].id : ''}
 									onSave={(): void => setIsUploading(false)}
+									queue={queue.current}
 								/>
 							</>
 						</Modal>

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -68,11 +68,18 @@ const StyledContainer = styled.div`
 
 	.folders-menu {
 		padding: 1rem;
+		max-height: calc(100vh - 16rem);
 		background-color: #202228;
+    overflow: auto;
 
 		> ul {
 			padding: 0;
 		}
+	}
+
+	.files-view {
+		max-height: calc(100vh - 16rem);
+    overflow: auto;
 	}
 `;
 
@@ -293,7 +300,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 									<SubFolder folder={homeFolder} onSelect={setCurrentFolder} onToggle={toggleSelectedFolders} isRoot />
 								</div>
 							)}
-							<FileList files={shownFiles} viewFile={setShownFile} view={view} />
+							<FileList files={shownFiles} viewFile={setShownFile} view={view} className="files-view" />
 						</div>
 					</StyledContainer>
 					{shownFile && <PdfViewer file={shownFile} closeModal={resetShownFile} />}

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -17,7 +17,7 @@ import { MultiCataloguesForm } from '../forms/catalogues-form/multi-catalogues-f
 import { Checkbox } from '../inputs/checkbox';
 import css from '@emotion/css';
 import { Button } from '../button';
-import { GridIcon, ListIcon, SearchIcon, SyncIcon, UploadIcon } from '../icons/Icon';
+import { GridIcon, ListIcon, Pencil, SearchIcon, SyncIcon, Trash, UploadIcon } from '../icons/Icon';
 import { FileList, IView } from './file-list';
 import { CataloguesApiService } from '../../services/catalogues-api';
 import { ConfirmDelete } from '../confirm-delete';
@@ -132,6 +132,8 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 	const [isSyncing, setIsSyncing] = useState(false);
 	const [allSelected, setAllSelected] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
+
+	const isSelecting = selectedFiles.length > 0;
 
 	const [view, setView] = useState<IView>(() => {
 		return (localStorage.getItem('file-view') as IView) || 'table';
@@ -276,13 +278,13 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 							</div>
 							<div className="select-bar">
 									<Checkbox checked={allSelected} onChange={toggleSelectAll} label={allSelected ? 'Deseleziona tutti' : 'Seleziona tutti'} css={checkboxStyles} />
-									<Button onClick={startEditing} disabled={selectedFiles.length === 0}>Modifica file</Button>
-									<Button onClick={(): void => setIsDeleting(true)} disabled={selectedFiles.length === 0}>Elimina file</Button>
-									<Button onClick={toggleView} ghost icon={view === 'grid' ? ListIcon : GridIcon}>
+									{isSelecting && <Button onClick={startEditing} disabled={selectedFiles.length === 0} icon={Pencil} isExpanding>Modifica file</Button>}
+									{isSelecting && <Button onClick={(): void => setIsDeleting(true)} disabled={selectedFiles.length === 0} icon={Trash} ghost isExpanding>Elimina file</Button>}
+									{isInternal && <Button icon={SyncIcon} onClick={syncServer} disabled={isSyncing} ghost isExpanding>Sincronizza</Button>}
+									{isInternal && <Button icon={UploadIcon} onClick={(): void => setIsUploading(true)} isExpanding>Carica file</Button>}
+									<Button onClick={toggleView} ghost icon={view === 'grid' ? ListIcon : GridIcon} isExpanding>
 										{view === 'grid' ? 'Tabella' : 'Griglia'}
 									</Button>
-									{isInternal && <Button icon={SyncIcon} onClick={syncServer} disabled={isSyncing}>Sincronizza</Button>}
-									{isInternal && <Button icon={UploadIcon} onClick={(): void => setIsUploading(true)}>Carica file</Button>}
 							</div>
 						</div>
 						<div className="filesystem-container">

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -17,8 +17,9 @@ import { MultiCataloguesForm } from '../forms/catalogues-form/multi-catalogues-f
 import { Checkbox } from '../inputs/checkbox';
 import css from '@emotion/css';
 import { Button } from '../button';
-import { GridIcon, ListIcon, SearchIcon } from '../icons/Icon';
+import { GridIcon, ListIcon, SearchIcon, SyncIcon } from '../icons/Icon';
 import { FileList, IView } from './file-list';
+import { CataloguesApiService } from '../../services/catalogues-api';
 
 const StyledContainer = styled.div`
 	margin: 2rem auto;
@@ -130,6 +131,8 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 	const startEditing = (): void => setIsEditing(true);
 	const finishEditing = (): void => setIsEditing(false);
 
+	const [isSyncing, setIsSyncing] = useState(false);
+
 	const [allSelected, setAllSelected] = useState(false);
 
 	const [view, setView] = useState<IView>(() => {
@@ -179,6 +182,14 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 		localStorage.setItem('file-view', view === 'grid' ? 'table' : 'grid');
 
 		setView(view === 'grid' ? 'table' : 'grid');
+	}
+
+	const syncServer = async (): Promise<void> => {
+		setIsSyncing(true);
+
+		await CataloguesApiService.sync(() => {
+			setIsSyncing(false);
+		});
 	}
 
 	const setCurrentFolder = (folder: ICurrentFolder): void => folder.id ? setCurrentFolders([folder]) : setCurrentFolders([]);
@@ -258,6 +269,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 									<Button onClick={toggleView} ghost icon={view === 'grid' ? ListIcon : GridIcon}>
 										{view === 'grid' ? 'Tabella' : 'Griglia'}
 									</Button>
+									{isInternal && <Button icon={SyncIcon} onClick={syncServer} disabled={isSyncing}>Sincronizza</Button>}
 							</div>
 						</div>
 						<div className="filesystem-container">

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -36,8 +36,8 @@ const StyledContainer = styled.div`
 
 	.current-folder {
 		flex: 2;
-		padding: .5rem;
 		background-color: #24305e;
+		padding: .5rem;
 		color: #fff;
 		line-height: 2rem;
 	}
@@ -59,17 +59,28 @@ const StyledContainer = styled.div`
 	}
 
 	.select-bar {
-		width: 100%;
+		display: flex;
 		padding: .5rem;
+		width: 100%;
+		box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
+
+		.left {
+			flex: 1;
+		}
+	}
+
+	.select-all {
+		margin-right: 1rem;
 	}
 
 	.filesystem-container {
-		display: grid;
-		grid-template-columns: minmax(auto, 330px) 1fr;
+		display: flex;
 	}
 
 	.folders-menu {
 		padding: 1rem;
+		min-width: 200px;
+		max-width: 30%;
 		max-height: calc(100vh - 16rem);
 		background-color: #202228;
     overflow: auto;
@@ -80,6 +91,7 @@ const StyledContainer = styled.div`
 	}
 
 	.files-view {
+		flex: 1;
 		max-height: calc(100vh - 16rem);
     overflow: auto;
 	}
@@ -287,20 +299,24 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 								<SearchIcon id="filesystem-search-icon" alt="Cerca" />
 							</div>
 							<div className="select-bar">
-									<Checkbox checked={allSelected} onChange={toggleSelectAll} label={allSelected ? 'Deseleziona tutti' : 'Seleziona tutti'} />
+								<div className="left">
+									<Checkbox className="select-all" checked={allSelected} onChange={toggleSelectAll} label={allSelected ? 'Deseleziona tutti' : 'Seleziona tutti'} />
 									{isSelecting && <Button onClick={startEditing} disabled={selectedFiles.length === 0} icon={Pencil} isExpanding>Modifica file</Button>}
 									{isSelecting && <Button onClick={(): void => setIsDeleting(true)} disabled={selectedFiles.length === 0} icon={Trash} ghost isExpanding>Elimina file</Button>}
+								</div>
+								<div className="right">
 									{isInternal && <Button icon={SyncIcon} onClick={syncServer} disabled={isSyncing} ghost isExpanding>Sincronizza</Button>}
 									{isInternal && <Button icon={UploadIcon} onClick={(): void => setIsUploading(true)} isExpanding>Carica file</Button>}
-									<Button onClick={toggleView} ghost icon={view === 'grid' ? ListIcon : GridIcon} isExpanding>
+									{/* <Button onClick={toggleView} ghost icon={view === 'grid' ? ListIcon : GridIcon} isExpanding>
 										{view === 'grid' ? 'Tabella' : 'Griglia'}
-									</Button>
+									</Button> */}
 									<Button
 										onClick={(): void => setIsQueueOpen(!isQueueOpen)}
 										icon={MenuIcon}
 									>
 										{`Coda (${Object.keys(queue.current?.queue || {}).length})`}
 									</Button>
+								</div>
 							</div>
 						</div>
 						<div className="filesystem-container">

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -83,6 +83,7 @@ const StyledContainer = styled.div`
 		max-width: 30%;
 		max-height: calc(100vh - 16rem);
 		background-color: #202228;
+		box-shadow: rgb(0 0 0 / 12%) 1px 1px 3px, rgb(0 0 0 / 24%) 1px 1px 2px;
     overflow: auto;
 
 		> ul {

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -57,11 +57,12 @@ const StyledContainer = styled.div`
 
 	.select-bar {
 		width: 100%;
+		padding: .5rem;
 	}
 
 	.filesystem-container {
 		display: grid;
-		grid-template-columns: minmax(auto, 250px) 1fr;
+		grid-template-columns: minmax(auto, 330px) 1fr;
 	}
 
 	.folders-menu {

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -12,12 +12,12 @@ import { getCurrentFiles } from './utils/get-current-files';
 import { toggleAllSubfolders } from './utils/toggle-all-subfolders';
 import { PdfViewer } from '../pdf-viewer';
 import { Modal } from '../modal';
-import { CataloguesForm } from '../forms/catalogues-form';
+import { CataloguesForm, UploadCataloguesForm } from '../forms/catalogues-form';
 import { MultiCataloguesForm } from '../forms/catalogues-form/multi-catalogues-form';
 import { Checkbox } from '../inputs/checkbox';
 import css from '@emotion/css';
 import { Button } from '../button';
-import { GridIcon, ListIcon, SearchIcon, SyncIcon } from '../icons/Icon';
+import { GridIcon, ListIcon, SearchIcon, SyncIcon, UploadIcon } from '../icons/Icon';
 import { FileList, IView } from './file-list';
 import { CataloguesApiService } from '../../services/catalogues-api';
 
@@ -128,9 +128,11 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 	const resetShownFile = (): void => setShownFile(null);
 
 	const [isEditing, setIsEditing] = useState(false);
-
+	
 	const startEditing = (): void => setIsEditing(true);
 	const finishEditing = (): void => setIsEditing(false);
+
+	const [isUploading, setIsUploading] = useState(false);
 
 	const [isSyncing, setIsSyncing] = useState(false);
 
@@ -271,6 +273,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 										{view === 'grid' ? 'Tabella' : 'Griglia'}
 									</Button>
 									{isInternal && <Button icon={SyncIcon} onClick={syncServer} disabled={isSyncing}>Sincronizza</Button>}
+									{isInternal && <Button icon={UploadIcon} onClick={(): void => setIsUploading(true)}>Carica file</Button>}
 							</div>
 						</div>
 						<div className="filesystem-container">
@@ -296,6 +299,17 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 									<CataloguesForm file={selectedFiles[0]} onSave={finishEditing} />
 								</>
 							)}
+						</Modal>
+					)}
+					{isInternal && (
+						<Modal isOpen={isUploading} closeModal={(): void => setIsUploading(false)} className="modal-small">
+							<>
+								<h2>Carica file</h2>
+								<UploadCataloguesForm
+									selectedCategory={currentFolders.length === 1 ? currentFolders[0].id : ''}
+									onSave={(): void => setIsUploading(false)}
+								/>
+							</>
 						</Modal>
 					)}
 				</SelectedContext.Provider>

--- a/src/components/file-system/file-system.tsx
+++ b/src/components/file-system/file-system.tsx
@@ -83,10 +83,6 @@ const StyledContainer = styled.div`
 	}
 `;
 
-const checkboxStyles = css`
-	border: 1px solid black;
-`;
-
 export type ICurrentFolder = {
 	id: string;
 	label: string;
@@ -284,7 +280,7 @@ export const FileSystem: React.FC<IOrganisedData> = ({ files, categories, catego
 								<SearchIcon id="filesystem-search-icon" alt="Cerca" />
 							</div>
 							<div className="select-bar">
-									<Checkbox checked={allSelected} onChange={toggleSelectAll} label={allSelected ? 'Deseleziona tutti' : 'Seleziona tutti'} css={checkboxStyles} />
+									<Checkbox checked={allSelected} onChange={toggleSelectAll} label={allSelected ? 'Deseleziona tutti' : 'Seleziona tutti'} />
 									{isSelecting && <Button onClick={startEditing} disabled={selectedFiles.length === 0} icon={Pencil} isExpanding>Modifica file</Button>}
 									{isSelecting && <Button onClick={(): void => setIsDeleting(true)} disabled={selectedFiles.length === 0} icon={Trash} ghost isExpanding>Elimina file</Button>}
 									{isInternal && <Button icon={SyncIcon} onClick={syncServer} disabled={isSyncing} ghost isExpanding>Sincronizza</Button>}

--- a/src/components/file-system/file.tsx
+++ b/src/components/file-system/file.tsx
@@ -1,5 +1,6 @@
-import React, { KeyboardEventHandler, MouseEventHandler, useMemo } from 'react';
-import { css, SerializedStyles } from '@emotion/core';
+import React, { KeyboardEventHandler, useMemo } from 'react';
+import { SerializedStyles } from '@emotion/core';
+import css from '@emotion/css';
 import styled from '@emotion/styled';
 import { ContextMenuParams, Item, Menu, TriggerEvent, useContextMenu } from 'react-contexify';
 
@@ -12,6 +13,7 @@ import { getFileDownloadUrl } from '../../services/firebase/storage';
 import { download } from './utils/browser-download';
 import { IView } from './file-list';
 import { formatBytes } from './utils/bytes-size';
+import { Checkbox } from '../inputs/checkbox';
 
 interface IFileProps {
 	file: IFile | IEnrichedFile;
@@ -19,12 +21,49 @@ interface IFileProps {
 	view: IView;
 }
 
-const StyledFile = styled.div<{ isSelected: boolean }>`
+type StyledProps = {
+	isSelected: boolean;
+}
+
+const StyledFile = styled.div<StyledProps>`
 	${(props): SerializedStyles => props.isSelected && css`
 		background: red;
 		
 		&.container:nth-of-type(even) {
 			background-color: rgba(255,0,0,.25);
+		}
+	`}
+`;
+
+const StyledRowFile = styled.tr<StyledProps>`
+	td {
+		position: relative;
+		padding: .75rem;
+		border-bottom: 1px solid #c6d4e8;
+	}
+
+	&:hover td {
+		background-color: #c6d4e8;
+		border-color: #98a4b5;
+	}
+
+	button {
+		width: 100%;
+		text-align: left;
+		font-size: 1rem;
+		cursor: pointer;
+	}
+`;
+
+const checkboxStyles = (checked: boolean): SerializedStyles => css`
+	&:after {
+		border: 1px solid #d2d2d2;
+    box-shadow: rgb(0 0 0 / 25%) 0px 0.0625em 0.0625em, rgb(0 0 0 / 25%) 0px 0.125em 0.5em, rgb(255 255 255 / 10%) 0px 0px 0px 1px inset;
+	}
+
+	${checked && css`
+		&:focus-within {
+			outline-color: #202228;
 		}
 	`}
 `;
@@ -60,7 +99,7 @@ export const File: React.FC<IFileProps> = ({ file, viewFile, view }) => {
 		}
 	}
 
-	const handleFileClick: MouseEventHandler = (event): void => {
+	const handleFileClick = (): void => {
 		selectFile(file);
 	}
 	
@@ -74,13 +113,21 @@ export const File: React.FC<IFileProps> = ({ file, viewFile, view }) => {
 
 	if (view === 'table') {
 		return (
-			<tr>
+			<StyledRowFile isSelected={isSelected}>
+				<td>
+					<Checkbox
+						ariaLabelledBy={`nome-${file.id}`}
+						checked={isSelected}
+						onChange={handleFileClick}
+						getStyles={checkboxStyles}
+					/>
+				</td>
 				<td>
 					<button
 						onContextMenu={handleContext}
-						onMouseUp={handleFileClick}
 						onDoubleClick={handleDoubleClick}
 						onKeyUp={handleKeyboard}
+						id={`nome-${file.id}`}
 					>
 						{file.label}
 					</button>
@@ -96,7 +143,7 @@ export const File: React.FC<IFileProps> = ({ file, viewFile, view }) => {
 					<Item onClick={handleDoubleClick}>{isInternal ? 'Visualizza' : 'Scarica'}</Item>
 					<Item onClick={startEditing}>Modifica catalogo</Item>
 				</Menu>
-			</tr>
+			</StyledRowFile>
 		)
 	}
 

--- a/src/components/file-system/file.tsx
+++ b/src/components/file-system/file.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { KeyboardEventHandler, useMemo } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import styled from '@emotion/styled';
 import { ContextMenuParams, Item, Menu, TriggerEvent, useContextMenu } from 'react-contexify';
@@ -33,10 +33,6 @@ export const File: React.FC<IFileProps> = ({ file, viewFile }) => {
 
 	const isSelected = useMemo(() => files.some(selectedFile => selectedFile.id === file.id), [files, file]);
 
-	const handleFileClick = (event: TriggerEvent, file: IFile | IEnrichedFile): void => {
-		selectFile(file);
-	}
-
 	const handleDoubleClick = async (): Promise<void> => {
 		if (isInternal) {
 			viewFile(file);
@@ -45,6 +41,21 @@ export const File: React.FC<IFileProps> = ({ file, viewFile }) => {
 
 		const url = await getFileDownloadUrl(file.storeUrl);
 		download(url, file.filename);
+	}
+
+	const handleKeyboard: KeyboardEventHandler = (event) => {
+		if (event.key === 'Enter') {
+			handleDoubleClick();
+			return;
+		}
+
+		if (event.key === 'Space') {
+			selectFile(file);
+		}
+	}
+
+	const handleFileClick = (event: TriggerEvent): void => {
+		selectFile(file);
 	}
 	
 	const handleContext = (event: TriggerEvent, params?: Pick<ContextMenuParams, "id" | "position" | "props">): void => {
@@ -59,8 +70,9 @@ export const File: React.FC<IFileProps> = ({ file, viewFile }) => {
 	<StyledFile isSelected={isSelected} className="container">
 		<button
 			onContextMenu={handleContext}
-			onClick={(e): void => handleFileClick(e, file)}
+			onClick={handleFileClick}
 			onDoubleClick={handleDoubleClick}
+			onKeyUp={handleKeyboard}
 		>
 			<Icon.PDFFile aria-hidden />
 			{file.label}

--- a/src/components/file-system/file.tsx
+++ b/src/components/file-system/file.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEventHandler, useMemo } from 'react';
+import React, { KeyboardEventHandler, MouseEventHandler, useMemo } from 'react';
 import { css, SerializedStyles } from '@emotion/core';
 import styled from '@emotion/styled';
 import { ContextMenuParams, Item, Menu, TriggerEvent, useContextMenu } from 'react-contexify';
@@ -49,12 +49,12 @@ export const File: React.FC<IFileProps> = ({ file, viewFile }) => {
 			return;
 		}
 
-		if (event.key === 'Space') {
+		if (event.key === ' ') {
 			selectFile(file);
 		}
 	}
 
-	const handleFileClick = (event: TriggerEvent): void => {
+	const handleFileClick: MouseEventHandler = (event): void => {
 		selectFile(file);
 	}
 	
@@ -70,7 +70,7 @@ export const File: React.FC<IFileProps> = ({ file, viewFile }) => {
 	<StyledFile isSelected={isSelected} className="container">
 		<button
 			onContextMenu={handleContext}
-			onClick={handleFileClick}
+			onMouseUp={handleFileClick}
 			onDoubleClick={handleDoubleClick}
 			onKeyUp={handleKeyboard}
 		>

--- a/src/components/file-system/folders-tree.tsx
+++ b/src/components/file-system/folders-tree.tsx
@@ -8,6 +8,7 @@ import { CataloguesService } from '../../services/firebase/db';
 import { CategoriesForm } from '../forms/catalogues-form/categories-form';
 import { CaretDown, CaretRight } from '../icons/Icon';
 import { Checkbox } from '../inputs/checkbox';
+import { HiddenContent } from '../hidden-content/hidden-content';
 
 interface IFoldersTreeProps {
 	folders: IOrganisedCategories;
@@ -193,19 +194,21 @@ export const SubFolder: React.FC<ISubFolderProps> = ({
 					) : (
 						<div onContextMenu={show} className="single-folder">
 							{!isRoot && (
-								<Checkbox
-									ariaLabelledBy={`folder-name-${folder.id}`}
-									checked={isActive}
-									onChange={handleToggle}
-								/>
+								<>
+									<Checkbox
+										ariaLabelledBy={`folder-name-${folder.id}`}
+										checked={isActive}
+										onChange={handleToggle}
+									/>
+									<HiddenContent id={`folder-name-${folder.id}`}>Seleziona {folder.label} {isRoot ? '' : `(${folder.fileCount})`}</HiddenContent>
+								</>
 							)}
 							<FolderContainer hasSubfolders={!!folder.subfolders} onClick={toggleExpanded}>
 								{folder.subfolders && (isExpanded ? <CaretDown /> : <CaretRight />)}
 								<span
-									id={`folder-name-${folder.id}`}
 									className="folder-label"
 								>
-									{folder.label} {isRoot ? '' : `(${folder.fileCount})`}
+									<HiddenContent>Espandi </HiddenContent>{folder.label} {isRoot ? '' : `(${folder.fileCount})`}
 								</span>
 							</FolderContainer>
 							</div>

--- a/src/components/file-system/folders-tree.tsx
+++ b/src/components/file-system/folders-tree.tsx
@@ -200,7 +200,7 @@ export const SubFolder: React.FC<ISubFolderProps> = ({
 										checked={isActive}
 										onChange={handleToggle}
 									/>
-									<HiddenContent id={`folder-name-${folder.id}`}>Seleziona {folder.label} {isRoot ? '' : `(${folder.fileCount})`}</HiddenContent>
+									<HiddenContent id={`folder-name-${folder.id}`}>Seleziona {folder.label} {!isRoot && folder.fileCount > 0 ? `(${folder.fileCount})` : ''}</HiddenContent>
 								</>
 							)}
 							<FolderContainer hasSubfolders={!!folder.subfolders} onClick={toggleExpanded}>
@@ -208,7 +208,7 @@ export const SubFolder: React.FC<ISubFolderProps> = ({
 								<span
 									className="folder-label"
 								>
-									<HiddenContent>Espandi </HiddenContent>{folder.label} {isRoot ? '' : `(${folder.fileCount})`}
+									<HiddenContent>Espandi </HiddenContent>{folder.label} {!isRoot && folder.fileCount > 0 ? `(${folder.fileCount})` : ''}
 								</span>
 							</FolderContainer>
 							</div>

--- a/src/components/file-system/queue-visualiser.tsx
+++ b/src/components/file-system/queue-visualiser.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { IJob, Queue } from '../../utils/queue';
+
+interface IQueueVisualiserProps {
+	queue: Queue<'sync' | 'upload'>;
+}
+
+const JobCard: React.FC<{ job: IJob<'sync' | 'upload'>; queue: Queue<'sync' | 'upload'> }> = ({ job, queue }) => {
+	const [localJob, setLocalJob] = useState(job);
+
+	useEffect(() => {
+		queue.listen(job.id, (job) => {
+			setLocalJob({ ...job });
+		});
+	}, []);
+
+	return (
+		<p>{localJob.label} - {localJob.status}</p>
+	);
+}
+
+export const QueueVisualiser: React.FC<IQueueVisualiserProps> = ({ queue }) => {
+	return (
+		<div>
+			{Object.values(queue.queue).map(job => <JobCard key={job.id} queue={queue} job={job} />)}
+		</div>
+	)
+};

--- a/src/components/file-system/queue-visualiser.tsx
+++ b/src/components/file-system/queue-visualiser.tsx
@@ -1,10 +1,10 @@
 import { css, SerializedStyles } from '@emotion/core';
 import styled from '@emotion/styled';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ISyncStatuses } from '../../services/catalogues-api/catalogues-service';
 import { useEscKey } from '../../shared/hooks';
 import { IJob, Queue } from '../../utils/queue';
-import { ErrorIcon, LoadingIcon, SuccessIcon, SyncIcon, UploadIcon } from '../icons/Icon';
+import { CloseIcon, ErrorIcon, LoadingIcon, SuccessIcon, SyncIcon, UploadIcon } from '../icons/Icon';
 
 interface IQueueVisualiserProps {
 	queue: Queue<'sync' | 'upload'>;
@@ -39,6 +39,13 @@ const StyledPanel = styled.div<{ isOpen: boolean }>`
 		margin-bottom: 2rem;
 		font-size: 1.5rem;
 		font-weight: bold;
+	}
+
+	.close-button {
+		position: absolute;
+    right: 1.5rem;
+    font-size: 1.5rem;
+    top: 1.5rem;
 	}
 	
 	${(props): SerializedStyles => props.isOpen && css`
@@ -119,6 +126,7 @@ export const QueueVisualiser: React.FC<IQueueVisualiserProps> = ({ queue, isOpen
 
 	return (
 		<StyledPanel isOpen={isOpen}>
+			<button className="close-button" onClick={close}><CloseIcon aria-label="Chiudi coda" /></button>
 			<h2>Lavori in coda</h2>
 			<ul>
 				{Object.values(queue.queue).map(job => (

--- a/src/components/file-system/queue-visualiser.tsx
+++ b/src/components/file-system/queue-visualiser.tsx
@@ -1,11 +1,96 @@
-import React, { useEffect, useState } from 'react';
+import { css, SerializedStyles } from '@emotion/core';
+import styled from '@emotion/styled';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ISyncStatuses } from '../../services/catalogues-api/catalogues-service';
+import { useEscKey } from '../../shared/hooks';
 import { IJob, Queue } from '../../utils/queue';
+import { ErrorIcon, LoadingIcon, SuccessIcon, SyncIcon, UploadIcon } from '../icons/Icon';
 
 interface IQueueVisualiserProps {
 	queue: Queue<'sync' | 'upload'>;
+	isOpen: boolean;
+	close: () => void;
 }
 
-const JobCard: React.FC<{ job: IJob<'sync' | 'upload'>; queue: Queue<'sync' | 'upload'> }> = ({ job, queue }) => {
+interface IJobCardProps {
+	job: IJob<'sync' | 'upload'>;
+	queue: Queue<'sync' | 'upload'>;
+}
+
+const statusColours = {
+	'in-progress': '#000',
+	errored: 'red',
+	succeeded: 'green',
+}
+
+const StyledPanel = styled.div<{ isOpen: boolean }>`
+	position: fixed;
+	height: 100vh;
+	right: -30vw;
+	width: 30vw;
+	top: 0;
+	padding: 2rem;
+	background: #fff;
+	box-shadow: rgba(0, 0, 0, 0.19) 0px 10px 20px, rgba(0, 0, 0, 0.23) 0px 6px 6px;
+	z-index: 5;
+	transition: all .3s ease-in-out;
+
+	h2 {
+		margin-bottom: 2rem;
+		font-size: 1.5rem;
+		font-weight: bold;
+	}
+	
+	${(props): SerializedStyles => props.isOpen && css`
+		right: 0px;
+	`}
+`;
+
+const StyledCard = styled.div<{ status: ISyncStatuses }>`
+	display: flex;
+	margin-bottom: 1rem;
+	border-bottom: 1px solid #c6d4e8;
+	padding-bottom: 1rem;
+
+	.type {
+		margin-right: 1rem;
+	}
+
+	.card-header {
+		flex: 1;
+	}
+
+	.status {
+		color: ${(props): string => statusColours[props.status]};
+		${(props): string => props.status === 'in-progress' && `animation: rotation .5s infinite linear;`}
+	}
+
+	@keyframes rotation {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(359deg);
+		}
+	}
+`;
+
+const statusIconsMapping = {
+	'in-progress': {
+		icon: LoadingIcon,
+		label: 'In corso',
+	},
+	errored: {
+		icon: ErrorIcon,
+		label: 'Fallito',
+	},
+	succeeded: {
+		icon: SuccessIcon,
+		label: 'Completato',
+	}
+}
+
+const JobCard: React.FC<IJobCardProps> = ({ job, queue }) => {
 	const [localJob, setLocalJob] = useState(job);
 
 	useEffect(() => {
@@ -14,15 +99,34 @@ const JobCard: React.FC<{ job: IJob<'sync' | 'upload'>; queue: Queue<'sync' | 'u
 		});
 	}, []);
 
+	const Icon = statusIconsMapping[localJob.status].icon;
+
 	return (
-		<p>{localJob.label} - {localJob.status}</p>
+		<StyledCard status={localJob.status}>
+			{localJob.type === 'sync' ? (
+				<SyncIcon className="type" aria-label="Sincronizzazione" />
+			) : (
+				<UploadIcon className="type" aria-label="Caricamento file" />
+			)}
+			<p className="card-header"><strong>{localJob.label}</strong></p>
+			<Icon className="status" aria-label={statusIconsMapping[localJob.status].label} />
+		</StyledCard>
 	);
 }
 
-export const QueueVisualiser: React.FC<IQueueVisualiserProps> = ({ queue }) => {
+export const QueueVisualiser: React.FC<IQueueVisualiserProps> = ({ queue, isOpen, close }) => {
+	useEscKey(close);
+
 	return (
-		<div>
-			{Object.values(queue.queue).map(job => <JobCard key={job.id} queue={queue} job={job} />)}
-		</div>
+		<StyledPanel isOpen={isOpen}>
+			<h2>Lavori in coda</h2>
+			<ul>
+				{Object.values(queue.queue).map(job => (
+					<li key={job.id}>
+						<JobCard queue={queue} job={job} />
+					</li>
+				))}
+			</ul>
+		</StyledPanel>
 	)
 };

--- a/src/components/file-system/utils/bytes-size.ts
+++ b/src/components/file-system/utils/bytes-size.ts
@@ -1,0 +1,11 @@
+export const formatBytes = (bytes: number, decimals = 2): string => {
+	if (bytes === 0) return '0 Bytes';
+
+	const k = 1024;
+	const dm = decimals < 0 ? 0 : decimals;
+	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}

--- a/src/components/file-system/utils/bytes-size.ts
+++ b/src/components/file-system/utils/bytes-size.ts
@@ -1,9 +1,9 @@
-export const formatBytes = (bytes: number, decimals = 2): string => {
+export const formatBytes = (bytes: number, decimals = 0): string => {
 	if (bytes === 0) return '0 Bytes';
 
 	const k = 1024;
 	const dm = decimals < 0 ? 0 : decimals;
-	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+	const sizes = ['Bytes', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
 	const i = Math.floor(Math.log(bytes) / Math.log(k));
 

--- a/src/components/form-fields/file-upload/file-upload.tsx
+++ b/src/components/form-fields/file-upload/file-upload.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { ErrorMessage, useField } from 'formik';
+import styled from '@emotion/styled';
+
+import { Icon } from '../../icons';
+
+export interface IFieldProps {
+  name: string;
+  label?: string;
+  hint?: string;
+  small?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export const StyledField = styled.div<{ small?: boolean }>`
+  margin-bottom: .5rem;
+  font-size: ${(props): string => props.small ? '1.5rem' : '1rem'};
+
+  label {
+    display: block;
+    margin-bottom: .35em;
+    font-size: 1.2em;
+  }
+
+  .hint {
+    display: block;
+    margin-bottom: .35em;
+  }
+
+  .field {
+    margin-bottom: .5em;
+    padding: .25em;
+    width: 100%;
+    font-size: 1em;
+    color: #000;
+    box-sizing: border-box;
+  }
+
+  .error {
+    font-size: 1em;
+    color: #9e1500;
+  }
+`;
+
+export const UploadField: React.FC<IFieldProps> = ({ name, label, hint, small, ...rest }) => {
+	const [{ value }, meta, { setValue }] = useField(name);
+
+	const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+		const newFiles = Array.from(e.currentTarget.files);
+
+		setValue(newFiles)
+	}
+
+  return (
+    <StyledField className="field-container" small={small}>
+			<label htmlFor={name}>{label}</label>
+			{hint && <span className="hint"><Icon.InfoCircle /> {hint}</span>}
+			<input type="file" name={name} {...rest} onChange={handleChange} />
+			<span className="error"><ErrorMessage name={name} /></span>
+    </StyledField>
+  )
+}

--- a/src/components/form-fields/file-upload/index.ts
+++ b/src/components/form-fields/file-upload/index.ts
@@ -1,0 +1,1 @@
+export { UploadField } from './file-upload';

--- a/src/components/forms/catalogues-form/index.ts
+++ b/src/components/forms/catalogues-form/index.ts
@@ -1,2 +1,4 @@
 export * from './categories-form';
 export * from './catalogues-form';
+export * from './multi-catalogues-form';
+export * from './upload-catalogues-form';

--- a/src/components/forms/catalogues-form/upload-catalogues-form.tsx
+++ b/src/components/forms/catalogues-form/upload-catalogues-form.tsx
@@ -7,16 +7,12 @@ import { Button } from '../../button';
 import { useCatalogueUtilities } from '../../file-system';
 import { Select, SelectOption } from '../../form-fields/select';
 import { UploadField } from '../../form-fields/file-upload';
+import { INewFile } from '../../../services/firebase/db';
+import { CataloguesApiService } from '../../../services/catalogues-api';
 
 interface IUploadCataloguesFormProps {
 	selectedCategory?: string;
 	onSave: () => void;
-}
-
-type INewFile = {
-	files: FileList;
-	categoriesId?: string[];
-	label?: string;
 }
 
 type ICatalogueError = {
@@ -58,29 +54,25 @@ export const UploadCataloguesForm: React.FC<IUploadCataloguesFormProps> = ({ sel
   const submitCatalogue: (values: INewFile, formikHelpers: FormikHelpers<any>) => void = async (values, { resetForm }) => {
     setIsSaving(true);
 
-		console.log(values);
-
     try {
-      // await CataloguesService.editCatalogue({ label: values.label, categoriesId: values.categoriesId }, fileToPass);
+      await CataloguesApiService.uploadCatalogues(values);
+
+      if (typeof onSave === 'function') {
+        onSave();
+      }
+  
+      if (isMounted.current === true) {
+        setIsSaving(false);
+        resetForm({});
+      }
     } catch (e) {
       console.error(e);
     }
-
-		if (typeof onSave === 'function') {
-			onSave();
-		}
-
-		if (isMounted.current === true) {
-			setIsSaving(false);
-			resetForm({});
-		}
   }
 
   const validateCatalogue: (values: INewFile) => ICatalogueError = (values) => {
     const { label, files } = values;
 
-		console.log(values.files.length)
-		
 		if (files.length === 0) {
 			return {
 				files: 'Seleziona almeno un file',

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -65,6 +65,9 @@ export const Header: () => JSX.Element = () => {
         <NavLink to="/cartello">
           Crea cartello
         </NavLink>
+        <NavLink to="/cataloghi">
+          Cataloghi
+        </NavLink>
         <button className="log-out" onClick={logout}>Esci</button>
       </nav>
       <div className="logo-container">

--- a/src/components/hidden-content/hidden-content.tsx
+++ b/src/components/hidden-content/hidden-content.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+export const HiddenContent: React.FC<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>> =
+	({ children, ...rest }) => <span className="visually-hidden" {...rest}>{children}</span>;

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -17,6 +17,10 @@ import {
   faSync,
   faUpload,
   faExclamationTriangle,
+  faBars,
+  faSpinner,
+  faCheckCircle,
+  faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons'
 
 export interface IIconProps {
@@ -88,4 +92,20 @@ export const UploadIcon: React.FC<IGenericProps> = (props) => (
 
 export const WarningIcon: React.FC<IGenericProps> = (props) => (
   <Icon icon={faExclamationTriangle} {...props} />
+)
+
+export const MenuIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faBars} {...props} />
+)
+
+export const LoadingIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faSpinner} {...props} />
+)
+
+export const SuccessIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faCheckCircle} {...props} />
+)
+
+export const ErrorIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faTimesCircle} {...props} />
 )

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -16,6 +16,7 @@ import {
   faList,
   faSync,
   faUpload,
+  faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons'
 
 export interface IIconProps {
@@ -83,4 +84,8 @@ export const SyncIcon: React.FC<IGenericProps> = (props) => (
 
 export const UploadIcon: React.FC<IGenericProps> = (props) => (
   <Icon icon={faUpload} {...props} />
+)
+
+export const WarningIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faExclamationTriangle} {...props} />
 )

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -14,6 +14,7 @@ import {
   faSearch,
   faTh,
   faList,
+  faSync,
 } from '@fortawesome/free-solid-svg-icons'
 
 export interface IIconProps {
@@ -73,4 +74,8 @@ export const GridIcon: React.FC<IGenericProps> = (props) => (
 
 export const ListIcon: React.FC<IGenericProps> = (props) => (
   <Icon icon={faList} {...props} />
+)
+
+export const SyncIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faSync} {...props} />
 )

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -21,6 +21,7 @@ import {
   faSpinner,
   faCheckCircle,
   faTimesCircle,
+  faTimes,
 } from '@fortawesome/free-solid-svg-icons'
 
 export interface IIconProps {
@@ -108,4 +109,8 @@ export const SuccessIcon: React.FC<IGenericProps> = (props) => (
 
 export const ErrorIcon: React.FC<IGenericProps> = (props) => (
   <Icon icon={faTimesCircle} {...props} />
+)
+
+export const CloseIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faTimes} {...props} />
 )

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -15,6 +15,7 @@ import {
   faTh,
   faList,
   faSync,
+  faUpload,
 } from '@fortawesome/free-solid-svg-icons'
 
 export interface IIconProps {
@@ -78,4 +79,8 @@ export const ListIcon: React.FC<IGenericProps> = (props) => (
 
 export const SyncIcon: React.FC<IGenericProps> = (props) => (
   <Icon icon={faSync} {...props} />
+)
+
+export const UploadIcon: React.FC<IGenericProps> = (props) => (
+  <Icon icon={faUpload} {...props} />
 )

--- a/src/components/inputs/checkbox/checkbox.tsx
+++ b/src/components/inputs/checkbox/checkbox.tsx
@@ -9,11 +9,12 @@ interface ICheckboxProps {
     label?: string;
     ariaLabelledBy?: string;
     onChange: () => void;
-    css?: SerializedStyles;
+    getStyles?: (checked: boolean) => SerializedStyles;
 }
 
 interface IStyledCheckboxProps {
     checked: boolean;
+    getStyles?: (checked: boolean) => SerializedStyles;
 }
 
 const StyledLabel = styled.label<IStyledCheckboxProps>`
@@ -44,6 +45,8 @@ const StyledLabel = styled.label<IStyledCheckboxProps>`
             background: #F13C20;
         }
     `}
+
+    ${(props): SerializedStyles => props?.getStyles?.(props.checked)}
 `;
 
 const StyledFakedLabel = styled.label<IStyledCheckboxProps>`
@@ -82,9 +85,11 @@ const StyledFakedLabel = styled.label<IStyledCheckboxProps>`
             content: none;
         }
     `}
+
+    ${(props): SerializedStyles => props?.getStyles?.(props.checked)}
 `;
 
-export const Checkbox: React.FC<ICheckboxProps> = ({ checked, label, ariaLabelledBy, onChange, css }) => {
+export const Checkbox: React.FC<ICheckboxProps> = ({ checked, label, ariaLabelledBy, onChange, getStyles }) => {
     if (!ariaLabelledBy && !label) {
         throw new Error('Sure you know what you are doing? Missing label and ariaLabelledBy');
     }
@@ -106,7 +111,7 @@ export const Checkbox: React.FC<ICheckboxProps> = ({ checked, label, ariaLabelle
     }
 
     return (
-        <StyledFakedLabel checked={checked} css={css}>
+        <StyledFakedLabel checked={checked} getStyles={getStyles}>
             {checked && <CheckboxCheckedIcon className="check" aria-hidden />}
             {!ariaLabelledBy && label}
             <input 

--- a/src/components/inputs/checkbox/checkbox.tsx
+++ b/src/components/inputs/checkbox/checkbox.tsx
@@ -10,6 +10,7 @@ interface ICheckboxProps {
     ariaLabelledBy?: string;
     onChange: () => void;
     getStyles?: (checked: boolean) => SerializedStyles;
+    className?: string;
 }
 
 interface IStyledCheckboxProps {
@@ -89,14 +90,14 @@ const StyledFakedLabel = styled.label<IStyledCheckboxProps>`
     ${(props): SerializedStyles => props?.getStyles?.(props.checked)}
 `;
 
-export const Checkbox: React.FC<ICheckboxProps> = ({ checked, label, ariaLabelledBy, onChange, getStyles }) => {
+export const Checkbox: React.FC<ICheckboxProps> = ({ checked, label, ariaLabelledBy, onChange, getStyles, className }) => {
     if (!ariaLabelledBy && !label) {
         throw new Error('Sure you know what you are doing? Missing label and ariaLabelledBy');
     }
 
     if (label) {
         return (
-            <StyledLabel checked={checked}>
+            <StyledLabel checked={checked} className={className}>
                 {checked && <CheckboxCheckedIcon className="check" aria-hidden />}
                 {label}
                 <input 
@@ -111,7 +112,7 @@ export const Checkbox: React.FC<ICheckboxProps> = ({ checked, label, ariaLabelle
     }
 
     return (
-        <StyledFakedLabel checked={checked} getStyles={getStyles}>
+        <StyledFakedLabel checked={checked} getStyles={getStyles} className={className}>
             {checked && <CheckboxCheckedIcon className="check" aria-hidden />}
             {!ariaLabelledBy && label}
             <input 

--- a/src/components/inputs/checkbox/checkbox.tsx
+++ b/src/components/inputs/checkbox/checkbox.tsx
@@ -66,16 +66,22 @@ const StyledFakedLabel = styled.label<IStyledCheckboxProps>`
         color: white;
         vertical-align: initial;
     }
+
+    &:focus-within:after {
+        outline: dashed 3px #F13C20;
+    }
     
     ${(props): string => props.checked && `
         background: #F13C20;
+
+        &:focus-within {
+            outline: dashed 3px #fff;
+        }
 
         &:after {
             content: none;
         }
     `}
-
-
 `;
 
 export const Checkbox: React.FC<ICheckboxProps> = ({ checked, label, ariaLabelledBy, onChange, css }) => {

--- a/src/components/pdf-viewer/pdf-viewer.tsx
+++ b/src/components/pdf-viewer/pdf-viewer.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { Global, css } from "@emotion/core";
 
-import { useStorageFile } from "../../shared/hooks";
+import { useConfig, useStorageFile } from "../../shared/hooks";
 import { Loader } from "../loader";
 import { Modal } from "../modal";
 
 import { IModalProps } from "../modal/modal";
 import { ErrorBoundary } from "../error-boundary/error-boundary";
 import { ViewerWithFixedError } from "./viewer-with-fixed-error";
+import { IFile } from "../../services/firebase/db";
+import { IEnrichedFile } from "../../utils/file-system";
 
 interface IPdfViewerProps {
-	url: string;
+	file: IFile | IEnrichedFile;
 }
 
 const modalCss = css`
@@ -25,13 +27,15 @@ const modalCss = css`
 	}
 `;
 
-export const PdfViewer: React.FC<IPdfViewerProps & Partial<IModalProps>> = ({ url, closeModal }) => {
-	const props = useStorageFile(url);
+export const PdfViewer: React.FC<IPdfViewerProps & Partial<IModalProps>> = ({ file, closeModal }) => {
+	const { isInternal, apiUrl } = useConfig();
+	const shownUrl = isInternal ? `${apiUrl}/file/${file.filename}` : file.storeUrl;
+	const props = useStorageFile(shownUrl);
 
 	return (
 		<>
 			<Global styles={modalCss} />
-			<Modal isOpen={!!url} closeModal={closeModal} className="pdf-viewer-modal">
+			<Modal isOpen={!!shownUrl} closeModal={closeModal} className="pdf-viewer-modal">
 				{!props ? (
 					<Loader />
 				) : (

--- a/src/services/catalogues-api/catalogues-couriers.ts
+++ b/src/services/catalogues-api/catalogues-couriers.ts
@@ -1,4 +1,5 @@
 import { IFile } from "../firebase/db";
+import { ISyncStatuses } from "./catalogues-service";
 
 export const apiExists: (url: string, token: string) => Promise<boolean> = async (apiUrl, token) => new Promise(async (resolve, reject) => {
 	try {
@@ -47,6 +48,38 @@ export const deleteCatalogue: (url: string, token: string, values: string) => Pr
 				body: JSON.stringify({ id: values }),
 			});
 			const res = await response.json();
+
+			resolve(res);
+		} catch (e) {
+			reject(e);
+		}
+	})
+}
+
+export const syncCatalogues: (url: string, token: string) => Promise<string> = (apiUrl, token) => {
+	return new Promise(async (resolve, reject) => {
+		try {
+			const response = await fetch(apiUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'x-access-token': token,
+				},
+			});
+			const res = await response.text();
+
+			resolve(res);
+		} catch (e) {
+			reject(e);
+		}
+	})
+}
+
+export const syncCataloguesStatus: (url: string, token: string) => Promise<ISyncStatuses> = (apiUrl, token) => {
+	return new Promise(async (resolve, reject) => {
+		try {
+			const response = await fetch(apiUrl);
+			const res = await response.text() as ISyncStatuses;
 
 			resolve(res);
 		} catch (e) {

--- a/src/services/catalogues-api/catalogues-couriers.ts
+++ b/src/services/catalogues-api/catalogues-couriers.ts
@@ -78,7 +78,7 @@ export const syncCatalogues: (url: string, token: string) => Promise<string> = (
 export const syncCataloguesStatus: (url: string, token: string) => Promise<ISyncStatuses> = (apiUrl, token) => {
 	return new Promise(async (resolve, reject) => {
 		try {
-			const response = await fetch(apiUrl);
+			const response = await fetch(apiUrl, { headers: { 'x-access-token': token } });
 			const res = await response.text() as ISyncStatuses;
 
 			resolve(res);

--- a/src/services/catalogues-api/catalogues-couriers.ts
+++ b/src/services/catalogues-api/catalogues-couriers.ts
@@ -1,14 +1,17 @@
-import { IFile } from "../firebase/db";
 import { ISyncStatuses } from "./catalogues-service";
 
 export const apiExists: (url: string, token: string) => Promise<boolean> = async (apiUrl, token) => new Promise(async (resolve, reject) => {
 	try {
-		await fetch(apiUrl, {
+		const response = await fetch(apiUrl, {
 			method: 'GET',
 			headers: {
 				'x-access-token': token,
 			},
 		});
+
+		if (!response.ok) {
+			throw new Error(`${response.status}`);
+		}
 
 		resolve(true);
 	} catch (e) {
@@ -16,7 +19,7 @@ export const apiExists: (url: string, token: string) => Promise<boolean> = async
 	}
 });
 
-export const uploadCatalogues: (url: string, token: string, values: FormData) => Promise<string> = (apiUrl, token, values) => {
+export const uploadCatalogues: (url: string, token: string, values: FormData) => Promise<string[]> = (apiUrl, token, values) => {
 	return new Promise(async (resolve, reject) => {
 		try {
 			const response = await fetch(apiUrl, {
@@ -26,7 +29,12 @@ export const uploadCatalogues: (url: string, token: string, values: FormData) =>
 				},
 				body: values,
 			});
-			const res = await response.text();
+
+			if (!response.ok) {
+				throw new Error(`${response.status}`);
+			}
+
+			const res = await response.json();
 
 			resolve(res);
 		} catch (e) {
@@ -46,6 +54,11 @@ export const deleteCatalogue: (url: string, token: string, values: string) => Pr
 				},
 				body: JSON.stringify({ id: values }),
 			});
+
+			if (!response.ok) {
+				throw new Error(`${response.status}`);
+			}
+
 			await response.text();
 
 			resolve();
@@ -65,6 +78,10 @@ export const syncCatalogues: (url: string, token: string) => Promise<string> = (
 					'x-access-token': token,
 				},
 			});
+			if (!response.ok) {
+				throw new Error(`${response.status}`);
+			}
+
 			const res = await response.text();
 
 			resolve(res);
@@ -78,6 +95,10 @@ export const syncCataloguesStatus: (url: string, token: string) => Promise<ISync
 	return new Promise(async (resolve, reject) => {
 		try {
 			const response = await fetch(apiUrl, { headers: { 'x-access-token': token } });
+			if (!response.ok) {
+				throw new Error(`${response.status}`);
+			}
+
 			const res = await response.text() as ISyncStatuses;
 
 			resolve(res);

--- a/src/services/catalogues-api/catalogues-couriers.ts
+++ b/src/services/catalogues-api/catalogues-couriers.ts
@@ -46,9 +46,9 @@ export const deleteCatalogue: (url: string, token: string, values: string) => Pr
 				},
 				body: JSON.stringify({ id: values }),
 			});
-			const res = await response.json();
+			await response.text();
 
-			resolve(res);
+			resolve();
 		} catch (e) {
 			reject(e);
 		}

--- a/src/services/catalogues-api/catalogues-couriers.ts
+++ b/src/services/catalogues-api/catalogues-couriers.ts
@@ -16,18 +16,17 @@ export const apiExists: (url: string, token: string) => Promise<boolean> = async
 	}
 });
 
-export const uploadCatalogue: (url: string, token: string, values: IFile) => Promise<void> = (apiUrl, token, values) => {
+export const uploadCatalogues: (url: string, token: string, values: FormData) => Promise<string> = (apiUrl, token, values) => {
 	return new Promise(async (resolve, reject) => {
 		try {
 			const response = await fetch(apiUrl, {
 				method: 'POST',
 				headers: {
-					'Content-Type': 'application/json',
 					'x-access-token': token,
 				},
-				body: JSON.stringify(values),
+				body: values,
 			});
-			const res = await response.json();
+			const res = await response.text();
 
 			resolve(res);
 		} catch (e) {

--- a/src/services/catalogues-api/catalogues-service.ts
+++ b/src/services/catalogues-api/catalogues-service.ts
@@ -32,6 +32,7 @@ class CataloguesApiServiceClass {
 		this.syncCourier = couriers.sync;
 		this.getSyncStatusCourier = couriers.syncStatus;
 		this.upload = couriers.upload;
+		this.delete = couriers.delete;
 	}
 
 	set apiUrl(url: string) {
@@ -89,6 +90,12 @@ class CataloguesApiServiceClass {
 
 		await this.refreshToken();
 		await this.upload(`${this.url}/files/create`, this.token, formData)
+	}
+
+	public async deleteCatalogue(id: string): Promise<void> {
+		await this.refreshToken();
+
+		await this.delete(`${this.url}/files/delete`, this.token, id);
 	}
 }
 

--- a/src/services/catalogues-api/catalogues-service.ts
+++ b/src/services/catalogues-api/catalogues-service.ts
@@ -1,6 +1,6 @@
 import { getToken } from "../firebase/auth";
 import { IFile } from "../firebase/db";
-import { apiExists, deleteCatalogue, uploadCatalogue } from "./catalogues-couriers";
+import { apiExists, deleteCatalogue, syncCatalogues, syncCataloguesStatus, uploadCatalogue } from "./catalogues-couriers";
 
 type ICall<T, P = void> = (url: string, token: string, ...args: T[]) => Promise<P>;
 
@@ -9,19 +9,28 @@ type ICouriers = {
 	checkExistance: ICall<undefined, boolean>;
 	upload: ICall<IFile>;
 	delete: ICall<string>;
+	sync: ICall<never, string>;
+	syncStatus: ICall<never, ISyncStatuses>;
 }
+
+export type ISyncStatuses = 'in-progress' | 'errored' | 'succeeded';
 
 class CataloguesApiServiceClass {
 	private url: string;
 	private token: string;
+	private syncCallId: string;
 	private getToken: () => Promise<string>;
 	private checkExistance: ICall<undefined, boolean>;
 	private upload: ICall<IFile>;
 	private delete: ICall<string>;
+	private syncCourier: ICall<never, string>;
+	private getSyncStatusCourier: ICall<never, ISyncStatuses>;
 
 	constructor(couriers: ICouriers) {
 		this.getToken = couriers.getToken;
 		this.checkExistance = couriers.checkExistance;
+		this.syncCourier = couriers.sync;
+		this.getSyncStatusCourier = couriers.syncStatus;
 	}
 
 	set apiUrl(url: string) {
@@ -39,6 +48,32 @@ class CataloguesApiServiceClass {
 
 		return apiExists;
 	}
+
+	public async sync(callback: (status: 'succeeded' | 'errored') => void): Promise<void> {
+		await this.refreshToken();
+
+		const token = await this.syncCourier(`${this.url}/files/sync`, this.token);
+
+		this.syncCallId = token;
+
+		this.pollSyncStatus(callback);
+	}
+
+	public async pollSyncStatus(callback: (status: 'succeeded' | 'errored') => void): Promise<void> {
+		await this.refreshToken();
+
+		const status = await this.getSyncStatusCourier(`${this.url}/files/queue/${this.syncCallId}`, this.token);
+
+		if (status === 'in-progress') {
+			setTimeout(() => {
+				this.pollSyncStatus(callback);
+			}, 500);
+
+			return;
+		}
+
+		callback(status);
+	}
 }
 
 export const CataloguesApiService = new CataloguesApiServiceClass({
@@ -46,4 +81,6 @@ export const CataloguesApiService = new CataloguesApiServiceClass({
 	checkExistance: apiExists,
 	upload: uploadCatalogue,
 	delete: deleteCatalogue,
+	sync: syncCatalogues,
+	syncStatus: syncCataloguesStatus
 });

--- a/src/services/firebase/db/catalogues/catalogues-service.ts
+++ b/src/services/firebase/db/catalogues/catalogues-service.ts
@@ -74,11 +74,17 @@ export class CataloguesServiceClass {
 				({
 					categories_id: categoriesId,
 					store_url: storeUrl,
+					created_at: createdAt,
+					created_by: createdBy,
+					dimension,
 					...rest
 				}) => ({
 					...rest,
 					categoriesId: categoriesId || [],
-					storeUrl
+					storeUrl,
+					createdAt: new Date(createdAt),
+					createdBy: createdBy,
+					dimension: dimension
 				})
 			)
 		);
@@ -113,13 +119,15 @@ export class CataloguesServiceClass {
 
 	public async editCatalogue(values: IFileChanges, data: IFile): Promise<void> {
 		const { label, categoriesId } = values;
-		const { storeUrl, ...rest } = data;
+		const { storeUrl, createdAt, createdBy, ...rest } = data;
 
 		await this.editCatalogueCourier({
 			...rest,
 			label,
 			categories_id: categoriesId || [],
 			store_url: storeUrl,
+			created_at: createdAt.getTime(),
+			created_by: createdBy,
 		});
 	}
 }

--- a/src/services/firebase/db/types.ts
+++ b/src/services/firebase/db/types.ts
@@ -74,6 +74,9 @@ export interface IDbFile {
   id: string;
   label: string;
   store_url: string;
+  created_at: number;
+  created_by: string;
+  dimension: number;
 }
 
 export interface IFile {
@@ -82,6 +85,9 @@ export interface IFile {
   id: string;
   label: string;
   storeUrl: string;
+  createdAt: Date;
+  createdBy: string;
+  dimension: number;
 }
 
 export interface IFileChanges {

--- a/src/services/firebase/db/types.ts
+++ b/src/services/firebase/db/types.ts
@@ -89,6 +89,18 @@ export interface IFileChanges {
   categoriesId: string[];
 }
 
+export type INewFile = {
+  files: File[];
+  categoriesId?: string[];
+  label?: string;
+}
+
+export type IApiFile = {
+  label?: string;
+  categories?: string[];
+  pdf_catalogues: [];
+}
+
 export interface ICategory {
   id: string;
   label: string;

--- a/src/shared/hooks/useEscKey.ts
+++ b/src/shared/hooks/useEscKey.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-export const useEscKey = (fn: () => void, condition?: boolean): void => {
+export const useEscKey = (fn: () => void, condition = true): void => {
 	useEffect(() => {
 		const listener = (e: KeyboardEvent): void => {
 			if (e.key === 'Escape' && condition) {

--- a/src/utils/file-system/normaliser.test.ts
+++ b/src/utils/file-system/normaliser.test.ts
@@ -7,6 +7,9 @@ const cataloguesData = [
 		id: 'cat-id-1',
 		label: 'test catalogue',
 		storeUrl: 'https://test.it',
+		createdBy: 'test',
+		createdAt: new Date(),
+		dimension: 16
 	},
 	{
 		categoriesId: ['category-id-3'],
@@ -14,6 +17,9 @@ const cataloguesData = [
 		id: 'cat-id-3',
 		label: 'test catalogue 2',
 		storeUrl: 'https://test.it',
+		createdBy: 'test',
+		createdAt: new Date(),
+		dimension: 16
 	},
 	{
 		categoriesId: ['category-id-3', 'category-id-1', 'category-id-4'],
@@ -21,6 +27,9 @@ const cataloguesData = [
 		id: 'cat-id-3',
 		label: 'test catalogue 2',
 		storeUrl: 'https://test.it',
+		createdBy: 'test',
+		createdAt: new Date(),
+		dimension: 16
 	},
 ];
 
@@ -32,6 +41,9 @@ const organisedCatalogues = {
 			id: 'cat-id-1',
 			label: 'test catalogue',
 			storeUrl: 'https://test.it',
+			createdBy: 'test',
+			createdAt: new Date(),
+			dimension: 16
 		},
 		{
 			categoriesId: ['category-id-3', 'category-id-1', 'category-id-4'],
@@ -39,6 +51,9 @@ const organisedCatalogues = {
 			id: 'cat-id-3',
 			label: 'test catalogue 2',
 			storeUrl: 'https://test.it',
+			createdBy: 'test',
+			createdAt: new Date(),
+			dimension: 16
 		},
 	],
 	'category-id-3': [
@@ -48,6 +63,9 @@ const organisedCatalogues = {
 			id: 'cat-id-3',
 			label: 'test catalogue 2',
 			storeUrl: 'https://test.it',
+			createdBy: 'test',
+			createdAt: new Date(),
+			dimension: 16
 		},
 		{
 			categoriesId: ['category-id-3', 'category-id-1', 'category-id-4'],
@@ -55,6 +73,9 @@ const organisedCatalogues = {
 			id: 'cat-id-3',
 			label: 'test catalogue 2',
 			storeUrl: 'https://test.it',
+			createdBy: 'test',
+			createdAt: new Date(),
+			dimension: 16
 		},
 	],
 	'category-id-4': [
@@ -64,6 +85,9 @@ const organisedCatalogues = {
 			id: 'cat-id-3',
 			label: 'test catalogue 2',
 			storeUrl: 'https://test.it',
+			createdBy: 'test',
+			createdAt: new Date(),
+			dimension: 16
 		},
 	],
 };

--- a/src/utils/file-system/normaliser.ts
+++ b/src/utils/file-system/normaliser.ts
@@ -24,6 +24,9 @@ export interface IEnrichedFile {
 	id: string;
 	label: string;
 	storeUrl: string;
+	createdAt: Date;
+	createdBy: string;
+	dimension: number;
 }
 
 export type IOrganisedCategories = IOrganisedCategoriesGeneric<ICategoryWithSubfolders>;

--- a/src/utils/queue/index.ts
+++ b/src/utils/queue/index.ts
@@ -1,0 +1,1 @@
+export * from './queue';

--- a/src/utils/queue/queue.ts
+++ b/src/utils/queue/queue.ts
@@ -1,0 +1,35 @@
+import { ISyncStatuses } from "../../services/catalogues-api/catalogues-service";
+
+export type IJob<T> = {
+	id: string;
+	label: string;
+	type: T;
+	status: ISyncStatuses;
+	listener?: (job: IJob<T>) => void;
+};
+
+export type IJobsQueue<T> = {
+	[id: string]: IJob<T>;
+}
+
+export class Queue<T> {
+	public queue: IJobsQueue<T>;
+
+	constructor() {
+		this.queue = {};
+	}
+
+	public push(job: Pick<IJob<T>, 'id' | 'label' | 'type'>): void {
+		this.queue[job.id] = { ...job, status: 'in-progress' };
+	}
+
+	public update(id: string, jobStatus: ISyncStatuses): void {
+		this.queue[id].status = jobStatus;
+
+		this.queue[id]?.listener?.(this.queue[id]);
+	}
+
+	public listen(id: string, listener: (job: IJob<T>) => void): void {
+		this.queue[id].listener = listener;
+	}
+}


### PR DESCRIPTION
## Description
Several design and functionality tweaks

## Changes
- Added sync icon
- Added sync status to Catalogues Service
- Added sync button to UI
- Added keyboard interaction to filesystem
- Added HiddenContent
- Added focus style for folder list
- UI Tweaks
- Added file upload component
- Added upload catalogue form
- Added upload icon
- Added upload to file system
- Added uploadCatalogues to api service
- Added upload catalogue to submit form
- Refactored pdf-viewer to self-contain url logic
- Adding delete file to catalogue api service
- Added confirm delete component
- Added elete to file system
- Added warning icon
- Added expanding buttons
- Set scroll to file view
- Changed to proper table
- Added full type from db
- Added format bytes util
- Improved table view
- Added Queue service
- Changed catalogue service to send to queue service
- Added QueueVisualiser
- Added Queue to file system
- Adding status icons
- Added queue visualiser open to filesystem
- Added styles to QueueVisualiser
- Added close button
- Added proper error handling to fetch cat api
- Added more resilient retrying to Cat Api Service
- Added Queue functionality to uploads
- Visual tweaks
- Added new page catalogues to menu