### PR TITLE
fix: add log to show when user is not needed

### DIFF
--- a/src/services/firebase/server/auth/index.ts
+++ b/src/services/firebase/server/auth/index.ts
@@ -18,9 +18,32 @@ export async function getUser(headers: PassedHeaders) {
   const dbRef = ref(getDatabase(firebaseServerApp));
 
   try {
+    const uid = auth.currentUser.uid;
+
+    if (!uid) {
+      throw new Error('Unknown user - no uid');
+    }
+
     const snapshot = await get(child(dbRef, `users/${auth.currentUser.uid}`));
+
     if (!snapshot.exists()) {
-      throw new Error('Unknown user');
+      const displayName = auth.currentUser.displayName || 'no-name';
+      const email = auth.currentUser.providerData[0].email || 'no-email';
+
+      const data = {
+        displayName,
+        email,
+        isAdmin: false,
+      };
+
+      if (!email.match('@pieroni.it')) {
+        throw new Error(`Email not supported: ${email} - ${uid}`);
+      }
+
+      // need to create new user, log to be checked
+      throw new Error(
+        `User needs creation. Uid: ${uid}, data: ${JSON.stringify(data)}`
+      );
     }
 
     const { nome, cognome, ...rest }: IDbUser = snapshot.val();


### PR DESCRIPTION
This PR adds a log to identify when the UUID is not present in the db, so that it can be inspected and added manually to the console