### PR TITLE
feature: add teams and assign users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "pdfmake": "^0.2.18",
         "react": "^19.0.0",
         "react-aria-components": "^1.5.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^4.1.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -8294,6 +8295,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "pdfmake": "^0.2.18",
     "react": "^19.0.0",
     "react-aria-components": "^1.5.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(protected)/(with-header)/admin/users/page.tsx
+++ b/src/app/(protected)/(with-header)/admin/users/page.tsx
@@ -7,6 +7,7 @@ import { getUser } from '@/services/firebase/server';
 import template from '../../header-template.module.css';
 import { UserForm } from '@/components/user-form/user-form';
 import { getTeams, getUsers } from '@/services/firebase/server/firestore';
+import { TeamForm } from '@/components/team-form/team-form';
 
 export const metadata: Metadata = {
   title: 'Admin utenti - Intranet Pieroni srl',
@@ -19,7 +20,7 @@ export default async function Admin() {
 
   const isAdmin = currentUser?.isAdmin;
 
-  const [users, availableTeams] = await Promise.all([
+  const [users, teams] = await Promise.all([
     getUsers(currentHeaders),
     getTeams(currentHeaders),
   ]);
@@ -33,19 +34,30 @@ export default async function Admin() {
       <div className={template.header}>
         <h1>Gestisci gli utenti</h1>
       </div>
+
       <div className={styles.container}>
-        <>
-          <div className={styles.section}>
-            <h2>Utenti</h2>
-            {users.map((user) => (
-              <UserForm
-                user={user}
-                key={user.id}
-                availableTeams={availableTeams}
-              />
+        <div className={styles.section}>
+          <h2>Team</h2>
+          <div className={styles.linksContainer}>
+            {teams.map((team) => (
+              <TeamForm key={team.id} team={team} />
             ))}
+            <TeamForm
+              team={{
+                name: '',
+                id: '',
+              }}
+              isNew
+            />
           </div>
-        </>
+        </div>
+
+        <div className={styles.section}>
+          <h2>Utenti</h2>
+          {users.map((user) => (
+            <UserForm user={user} key={user.id} availableTeams={teams} />
+          ))}
+        </div>
       </div>
     </main>
   );

--- a/src/app/(protected)/(with-header)/admin/users/page.tsx
+++ b/src/app/(protected)/(with-header)/admin/users/page.tsx
@@ -6,7 +6,7 @@ import styles from '../page.module.css';
 import { getUser } from '@/services/firebase/server';
 import template from '../../header-template.module.css';
 import { UserForm } from '@/components/user-form/user-form';
-import { getTeams, getUsers } from '@/services/firebase/server/firestore';
+import { getTeams, getUsers } from '@/services/firebase/server';
 import { TeamForm } from '@/components/team-form/team-form';
 
 export const metadata: Metadata = {

--- a/src/app/(protected)/(with-header)/admin/users/page.tsx
+++ b/src/app/(protected)/(with-header)/admin/users/page.tsx
@@ -1,0 +1,52 @@
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+
+import styles from '../page.module.css';
+import { getUser } from '@/services/firebase/server';
+import template from '../../header-template.module.css';
+import { UserForm } from '@/components/user-form/user-form';
+import { getTeams, getUsers } from '@/services/firebase/server/firestore';
+
+export const metadata: Metadata = {
+  title: 'Admin utenti - Intranet Pieroni srl',
+  description: 'Intranet - gestisci le impostazioni utenti',
+};
+
+export default async function Admin() {
+  const currentHeaders = await headers();
+  const { currentUser } = await getUser(currentHeaders);
+
+  const isAdmin = currentUser?.isAdmin;
+
+  const [users, availableTeams] = await Promise.all([
+    getUsers(currentHeaders),
+    getTeams(currentHeaders),
+  ]);
+
+  if (!isAdmin) {
+    return redirect('/');
+  }
+
+  return (
+    <main className={template.page}>
+      <div className={template.header}>
+        <h1>Gestisci gli utenti</h1>
+      </div>
+      <div className={styles.container}>
+        <>
+          <div className={styles.section}>
+            <h2>Utenti</h2>
+            {users.map((user) => (
+              <UserForm
+                user={user}
+                key={user.id}
+                availableTeams={availableTeams}
+              />
+            ))}
+          </div>
+        </>
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -292,7 +292,8 @@ label:has(select) {
   margin-block-end: 0.5rem;
 
   input,
-  textarea {
+  textarea,
+  select {
     display: block;
     width: 100%;
     padding: 0.5rem;
@@ -315,14 +316,12 @@ select {
 
 option {
   background: var(--button-background);
+  padding: 0.25rem;
 
-  &:hover {
-    background: #050a18;
-  }
-
+  &:hover,
   &:checked {
-    background: #050a18;
-    color: white;
+    background: var(--background-highlight);
+    color: var(--text-highlight);
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -319,6 +319,11 @@ option {
   &:hover {
     background: #050a18;
   }
+
+  &:checked {
+    background: #050a18;
+    color: white;
+  }
 }
 
 textarea {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -18,7 +18,7 @@ type HeaderProps = {
       transport?: boolean;
     };
   };
-  theme?: 'light' | 'dark';
+  theme?: 'light' | 'dark' | null;
 };
 
 export function Header({ mailUrl, isAdmin, scopes, theme }: HeaderProps) {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -66,6 +66,7 @@ export function Header({ mailUrl, isAdmin, scopes, theme }: HeaderProps) {
           {(isAdmin || scopes?.config?.transport) && (
             <a {...getLinkProps('/admin')}>Admin</a>
           )}
+          {isAdmin && <a {...getLinkProps('/admin/users')}>Utenti e team</a>}
 
           <button className={styles.logOut} onClick={handleSignOut}>
             Esci

--- a/src/components/multiselect/multiselect.module.css
+++ b/src/components/multiselect/multiselect.module.css
@@ -1,0 +1,24 @@
+.fieldset {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  border: none;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  width: fit-content;
+  background: var(--button-background);
+  color: var(--button-text);
+  border-radius: var(--border-radius);
+  padding: 0.15rem;
+
+  input {
+    margin-right: 0.25rem;
+  }
+
+  span {
+    flex-shrink: 0;
+  }
+}

--- a/src/components/multiselect/multiselect.tsx
+++ b/src/components/multiselect/multiselect.tsx
@@ -1,0 +1,30 @@
+import { DetailedHTMLProps, InputHTMLAttributes } from 'react';
+
+import styles from './multiselect.module.css';
+
+type MultiSelectProps = {
+  options: {
+    value: string;
+    label: string;
+    isDefaultChecked: boolean;
+  }[];
+  name: string;
+} & DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
+
+export const MultiSelect = ({ options, name }: MultiSelectProps) => {
+  return (
+    <fieldset className={styles.fieldset}>
+      {options.map((option) => (
+        <label key={option.value} className={styles.label}>
+          <input
+            type="checkbox"
+            defaultChecked={option.isDefaultChecked}
+            value={option.value}
+            name={name}
+          />
+          <span>{option.label}</span>
+        </label>
+      ))}
+    </fieldset>
+  );
+};

--- a/src/components/multiselect/multiselect.tsx
+++ b/src/components/multiselect/multiselect.tsx
@@ -9,11 +9,13 @@ type MultiSelectProps = {
     isDefaultChecked: boolean;
   }[];
   name: string;
+  legend: string;
 } & DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
-export const MultiSelect = ({ options, name }: MultiSelectProps) => {
+export const MultiSelect = ({ options, name, legend }: MultiSelectProps) => {
   return (
     <fieldset className={styles.fieldset}>
+      <legend>{legend}</legend>
       {options.map((option) => (
         <label key={option.value} className={styles.label}>
           <input

--- a/src/components/team-form/team-action.ts
+++ b/src/components/team-form/team-action.ts
@@ -1,0 +1,83 @@
+'use server';
+
+import { headers } from 'next/headers';
+import { revalidatePath } from 'next/cache';
+
+import { FORM_FAIL_TEAM, FORM_SUCCESS_TEAM } from '@/consts';
+import { createTeam, deleteTeam, pushTeam } from '@/services/firebase/server';
+
+export type StateValidation = {
+  error?: string;
+  success?: string;
+};
+
+export const teamAction = async (_: StateValidation, values: FormData) => {
+  const currentHeaders = await headers();
+
+  try {
+    const formName = values.get('name');
+    const formId = values.get('id');
+    const formIsNew = values.get('isNew');
+
+    if (!formName) {
+      return {
+        error: FORM_FAIL_TEAM,
+      };
+    }
+
+    if (!formId && !formIsNew) {
+      return {
+        errors: {
+          general: FORM_FAIL_TEAM,
+        },
+      };
+    }
+
+    const name = String(formName);
+    const id = String(formId);
+    const isNew = String(formIsNew) === 'NEW';
+
+    if (isNew && !id) {
+      await createTeam(currentHeaders, {
+        name,
+      });
+    } else {
+      await pushTeam(currentHeaders, {
+        name,
+        id,
+      });
+    }
+
+    revalidatePath('/admin/users');
+    // do we need this? revalidateTag('teams');
+
+    return {
+      success: FORM_SUCCESS_TEAM,
+    };
+  } catch (e) {
+    console.error(e);
+    return {
+      errors: {
+        general: FORM_FAIL_TEAM,
+      },
+    };
+  }
+};
+
+export const teamDeleteAction = async (id: string) => {
+  const currentHeaders = await headers();
+
+  try {
+    if (!id) {
+      throw new Error('No id provided');
+    }
+
+    await deleteTeam(currentHeaders, id);
+
+    revalidatePath('/admin/users');
+    // do we need this? revalidateTag('teams');
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};

--- a/src/components/team-form/team-form.module.css
+++ b/src/components/team-form/team-form.module.css
@@ -1,0 +1,31 @@
+.container {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-block-end: 1.5rem;
+  border-block-end: 1px solid var(--border-0);
+  width: 100%;
+
+  @media (min-width: 1024px) {
+    flex-wrap: nowrap;
+    margin-block-end: 0;
+    border-block-end: none;
+  }
+}
+
+.container label {
+  flex-grow: 1;
+}
+
+.buttonsContainer {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  gap: 0.5rem;
+  margin-block-end: 0.5rem;
+
+  @media (min-width: 1024px) {
+    width: auto;
+  }
+}

--- a/src/components/team-form/team-form.tsx
+++ b/src/components/team-form/team-form.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useActionState } from 'react';
+
+import type { ITeam } from '@/services/firebase/db-types';
+import { teamAction, teamDeleteAction, StateValidation } from './team-action';
+import styles from './team-form.module.css';
+import { FormStatus } from '../form-status/form-status';
+import { DeleteIcon } from '../icons/delete';
+import { SaveIcon } from '../icons/save';
+
+type LinksFormProps = {
+  team: ITeam;
+  isNew?: boolean;
+};
+const initialState: StateValidation = {};
+
+export const TeamForm = ({
+  team: { name, id },
+  isNew = false,
+}: LinksFormProps) => {
+  const [state, formAction, pending] = useActionState(teamAction, initialState);
+
+  return (
+    <form action={formAction}>
+      <div className={styles.container}>
+        <label>
+          Nome
+          <input type="text" name="name" defaultValue={name} required />
+        </label>
+        <input type="hidden" name="id" value={id} />
+        <input type="hidden" name="isNew" value={isNew ? 'NEW' : ''} />
+        <div className={styles.buttonsContainer}>
+          <button type="submit" title={!isNew ? 'Salva' : 'Aggiungi'}>
+            {!isNew ? <SaveIcon role="presentation" /> : 'Aggiungi'}
+          </button>
+          {!isNew && (
+            <button
+              formAction={() => teamDeleteAction(id)}
+              title={`Rimuovi ${name}`}
+            >
+              <DeleteIcon role="presentation" />
+            </button>
+          )}
+        </div>
+      </div>
+      {!pending && <FormStatus text={state.success} type="success" />}
+      {!pending && <FormStatus text={state.error} type="error" />}
+    </form>
+  );
+};

--- a/src/components/theme-toggle/theme-toggle.tsx
+++ b/src/components/theme-toggle/theme-toggle.tsx
@@ -4,7 +4,7 @@ import { themeToggleAction } from './theme-toggle-action';
 import styles from './theme-toggle.module.css';
 
 type ThemeToggleProps = {
-  currentTheme?: 'light' | 'dark';
+  currentTheme?: 'light' | 'dark' | null;
 };
 
 const options = [

--- a/src/components/user-form/user-action.ts
+++ b/src/components/user-form/user-action.ts
@@ -1,0 +1,60 @@
+'use server';
+
+import { headers } from 'next/headers';
+import { revalidatePath, revalidateTag } from 'next/cache';
+
+import { FORM_FAIL_LINK, FORM_SUCCESS_LINK } from '@/consts';
+import { pushUser } from '@/services/firebase/server';
+import { IUser } from '@/services/firebase/db-types';
+
+export type StateValidation = {
+  error?: string;
+  success?: string;
+};
+
+export const userAction = async (
+  userData: IUser,
+  _: StateValidation,
+  values: FormData
+) => {
+  const currentHeaders = await headers();
+
+  try {
+    const formTeams = values.getAll('teams');
+
+    if (!formTeams) {
+      return {
+        error: FORM_FAIL_LINK,
+      };
+    }
+
+    if (!userData.id) {
+      return {
+        errors: {
+          general: FORM_FAIL_LINK,
+        },
+      };
+    }
+
+    const teams = formTeams.map((team) => String(team));
+
+    await pushUser(currentHeaders, {
+      ...userData,
+      teams,
+    });
+
+    revalidatePath('/admin');
+    revalidateTag('links');
+
+    return {
+      success: FORM_SUCCESS_LINK,
+    };
+  } catch (e) {
+    console.error(e);
+    return {
+      errors: {
+        general: FORM_FAIL_LINK,
+      },
+    };
+  }
+};

--- a/src/components/user-form/user-action.ts
+++ b/src/components/user-form/user-action.ts
@@ -1,9 +1,9 @@
 'use server';
 
 import { headers } from 'next/headers';
-import { revalidatePath, revalidateTag } from 'next/cache';
+import { revalidatePath } from 'next/cache';
 
-import { FORM_FAIL_LINK, FORM_SUCCESS_LINK } from '@/consts';
+import { FORM_FAIL_USER, FORM_SUCCESS_USER } from '@/consts';
 import { pushUser } from '@/services/firebase/server';
 import { IUser } from '@/services/firebase/db-types';
 
@@ -24,14 +24,14 @@ export const userAction = async (
 
     if (!formTeams) {
       return {
-        error: FORM_FAIL_LINK,
+        error: FORM_FAIL_USER,
       };
     }
 
     if (!userData.id) {
       return {
         errors: {
-          general: FORM_FAIL_LINK,
+          general: FORM_FAIL_USER,
         },
       };
     }
@@ -43,17 +43,17 @@ export const userAction = async (
       teams,
     });
 
-    revalidatePath('/admin');
-    revalidateTag('links');
+    revalidatePath('/admin/users');
+    // do we need this? revalidateTag('links');
 
     return {
-      success: FORM_SUCCESS_LINK,
+      success: FORM_SUCCESS_USER,
     };
   } catch (e) {
     console.error(e);
     return {
       errors: {
-        general: FORM_FAIL_LINK,
+        general: FORM_FAIL_USER,
       },
     };
   }

--- a/src/components/user-form/user-form.module.css
+++ b/src/components/user-form/user-form.module.css
@@ -1,6 +1,6 @@
 .container {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   flex-wrap: wrap;
   gap: 0.25rem;
   margin-block-end: 1.5rem;
@@ -14,13 +14,10 @@
   }
 }
 
-.container label {
-  flex-grow: 1;
-}
-
 .buttonsContainer {
   display: flex;
   justify-content: flex-end;
+  align-self: center;
   width: 100%;
   gap: 0.5rem;
   margin-block-end: 0.5rem;
@@ -28,4 +25,9 @@
   @media (min-width: 1024px) {
     width: auto;
   }
+}
+
+.selectContainer {
+  flex-grow: 1;
+  max-width: 50%;
 }

--- a/src/components/user-form/user-form.module.css
+++ b/src/components/user-form/user-form.module.css
@@ -1,0 +1,31 @@
+.container {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-block-end: 1.5rem;
+  border-block-end: 1px solid var(--border-0);
+  width: 100%;
+
+  @media (min-width: 1024px) {
+    flex-wrap: nowrap;
+    margin-block-end: 0;
+    border-block-end: none;
+  }
+}
+
+.container label {
+  flex-grow: 1;
+}
+
+.buttonsContainer {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  gap: 0.5rem;
+  margin-block-end: 0.5rem;
+
+  @media (min-width: 1024px) {
+    width: auto;
+  }
+}

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -1,21 +1,46 @@
 'use client';
 
+import { useActionState } from 'react';
+
 import { ITeam, IUser } from '@/services/firebase/db-types';
 import styles from './user-form.module.css';
 import { SaveIcon } from '../icons/save';
+import { MultiSelect } from '../multiselect/multiselect';
+import { StateValidation, userAction } from './user-action';
+import { FormStatus } from '../form-status/form-status';
 
 type UserFormProps = {
   user: IUser;
   availableTeams: ITeam[];
 };
 
+const initialState: StateValidation = {};
+
 export const UserForm = ({
-  user: { name, surname, email, id, teams },
+  user: { name, surname, email, id, teams, ...rest },
   availableTeams,
 }: UserFormProps) => {
-  // const [state, formAction, pending] = useActionState(linkAction, initialState);
+  const userActionWithPrevious = userAction.bind(null, {
+    name,
+    surname,
+    email,
+    id,
+    ...rest,
+  });
+
+  const [state, formAction, pending] = useActionState(
+    userActionWithPrevious,
+    initialState
+  );
+
+  const selectTeams = availableTeams.map((team) => ({
+    value: team.id,
+    label: team.name,
+    isDefaultChecked: !!teams?.some((current) => current === team.id),
+  }));
+
   return (
-    <form>
+    <form action={formAction}>
       <div className={styles.container}>
         <label>
           Nome
@@ -25,20 +50,9 @@ export const UserForm = ({
           Mail
           <input type="email" name="email" defaultValue={email} readOnly />
         </label>
-        <label>
-          Teams
-          <select name="teams" multiple>
-            {availableTeams.map((team) => (
-              <option
-                value={team.id}
-                key={team.id}
-                selected={teams?.some((current) => current === team.id)}
-              >
-                {team.name}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className={styles.selectContainer}>
+          <MultiSelect options={selectTeams} name="teams" />
+        </div>
         <input type="hidden" name="id" value={id} />
         <div className={styles.buttonsContainer}>
           <button type="submit" title="Salva">
@@ -46,8 +60,8 @@ export const UserForm = ({
           </button>
         </div>
       </div>
-      {/* {!pending && <FormStatus text={state.success} type="success" />}
-      {!pending && <FormStatus text={state.error} type="error" />} */}
+      {!pending && <FormStatus text={state.success} type="success" />}
+      {!pending && <FormStatus text={state.error} type="error" />}
     </form>
   );
 };

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -51,7 +51,7 @@ export const UserForm = ({
           <input type="email" name="email" defaultValue={email} readOnly />
         </label>
         <div className={styles.selectContainer}>
-          <MultiSelect options={selectTeams} name="teams" />
+          <MultiSelect options={selectTeams} name="teams" legend="Teams" />
         </div>
         <input type="hidden" name="id" value={id} />
         <div className={styles.buttonsContainer}>

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { ITeam, IUser } from '@/services/firebase/db-types';
+import styles from './user-form.module.css';
+import { SaveIcon } from '../icons/save';
+
+type UserFormProps = {
+  user: IUser;
+  availableTeams: ITeam[];
+};
+
+export const UserForm = ({
+  user: { name, surname, email, id, teams },
+  availableTeams,
+}: UserFormProps) => {
+  // const [state, formAction, pending] = useActionState(linkAction, initialState);
+  return (
+    <form>
+      <div className={styles.container}>
+        <label>
+          Nome
+          <input name="name" defaultValue={`${name} ${surname}`} readOnly />
+        </label>
+        <label>
+          Mail
+          <input type="email" name="email" defaultValue={email} readOnly />
+        </label>
+        <label>
+          Teams
+          <select name="teams" multiple>
+            {availableTeams.map((team) => (
+              <option
+                value={team.id}
+                key={team.id}
+                selected={teams?.some((current) => current === team.id)}
+              >
+                {team.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <input type="hidden" name="id" value={id} />
+        <div className={styles.buttonsContainer}>
+          <button type="submit" title="Salva">
+            <SaveIcon role="presentation" />
+          </button>
+        </div>
+      </div>
+      {/* {!pending && <FormStatus text={state.success} type="success" />}
+      {!pending && <FormStatus text={state.error} type="error" />} */}
+    </form>
+  );
+};

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -36,3 +36,9 @@ export const FORM_SUCCESS_CONFIG = '✔️ Configurazione aggiornata';
 export const FORM_FAIL_EMPTY = '❌ Almeno un campo è obbligatorio';
 export const FORM_FAIL_CONFIG =
   '❌ Non siamo riusciti ad aggiornare la configurazione. Ricontrolla per favore';
+export const FORM_SUCCESS_TEAM = '✔️ Team aggiornato';
+export const FORM_FAIL_TEAM =
+  '❌ Non siamo riusciti ad aggiornare il team. Ricontrolla per favore';
+export const FORM_SUCCESS_USER = '✔️ Utente aggiornato';
+export const FORM_FAIL_USER =
+  "❌ Non siamo riusciti ad aggiornare l'utente. Ricontrolla per favore";

--- a/src/services/firebase/db-types.ts
+++ b/src/services/firebase/db-types.ts
@@ -9,7 +9,7 @@ export interface IDbUser {
       transport?: boolean;
     };
   };
-  theme?: 'light' | 'dark';
+  theme?: 'light' | 'dark' | null;
   teams?: string[];
 }
 
@@ -25,7 +25,7 @@ export interface IUser {
       transport?: boolean;
     };
   };
-  theme?: 'light' | 'dark';
+  theme?: 'light' | 'dark' | null;
   teams?: string[];
 }
 

--- a/src/services/firebase/db-types.ts
+++ b/src/services/firebase/db-types.ts
@@ -10,6 +10,7 @@ export interface IDbUser {
     };
   };
   theme?: 'light' | 'dark';
+  teams?: string[];
 }
 
 export interface IUser {
@@ -25,6 +26,16 @@ export interface IUser {
     };
   };
   theme?: 'light' | 'dark';
+  teams?: string[];
+}
+
+export interface IDbTeam {
+  name: string;
+}
+
+export interface ITeam {
+  name: string;
+  id: string;
 }
 
 export interface IDbLinks {

--- a/src/services/firebase/server/db/index.ts
+++ b/src/services/firebase/server/db/index.ts
@@ -177,24 +177,6 @@ export const pushGoogleAuth = async (
   }
 };
 
-export const pushTheme = async (
-  headers: PassedHeaders,
-  data: 'light' | 'dark' | null
-) => {
-  const user = await getUser(headers);
-
-  if (!user.currentUser?.id) {
-    throw new Error('Missing user id');
-  }
-
-  try {
-    await update(headers, `users/${user.currentUser.id}`, { theme: data });
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
-};
-
 export const createLink = async (
   headers: PassedHeaders,
   data: Omit<ILink, 'id'>

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -1,0 +1,14 @@
+import { IDbUser } from '../../db-types';
+import { PassedHeaders } from '../serverApp';
+import { get } from './operations';
+
+export const getUsers = async (headers: PassedHeaders) => {
+  try {
+    const records = await get<IDbUser>(headers, 'users');
+
+    return records;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -1,8 +1,8 @@
 import * as z from 'zod';
-import { IDbUser, ITeam, IUser } from '../../db-types';
+import { IDbTeam, IDbUser, ITeam, IUser } from '../../db-types';
 import { TeamSchema, UserSchema } from '../../validator';
 import { PassedHeaders } from '../serverApp';
-import { getRecords, update } from './operations';
+import { create, getRecords, update, remove } from './operations';
 
 export const getUsers = async (headers: PassedHeaders) => {
   try {
@@ -52,6 +52,38 @@ export const getTeams = async (headers: PassedHeaders) => {
     });
 
     return records;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const pushTeam = async (headers: PassedHeaders, data: ITeam) => {
+  try {
+    const { id, ...teamData } = data;
+    const verifiedData = TeamSchema.parse(teamData);
+
+    await update<IDbTeam>(headers, ['teams', id], verifiedData);
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const createTeam = async (headers: PassedHeaders, data: IDbTeam) => {
+  try {
+    const verifiedData = TeamSchema.parse(data);
+
+    await create<IDbTeam>(headers, 'teams', verifiedData);
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const deleteTeam = async (headers: PassedHeaders, id: string) => {
+  try {
+    await remove(headers, 'teams', id);
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -1,8 +1,8 @@
 import * as z from 'zod';
-import { ITeam, IUser } from '../../db-types';
+import { IDbUser, ITeam, IUser } from '../../db-types';
 import { TeamSchema, UserSchema } from '../../validator';
 import { PassedHeaders } from '../serverApp';
-import { getRecords } from './operations';
+import { getRecords, update } from './operations';
 
 export const getUsers = async (headers: PassedHeaders) => {
   try {
@@ -19,6 +19,22 @@ export const getUsers = async (headers: PassedHeaders) => {
     });
 
     return records;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const pushUser = async (headers: PassedHeaders, data: IUser) => {
+  try {
+    const { name, surname, id, ...rest } = data;
+    const verifiedData = UserSchema.parse({
+      nome: name,
+      cognome: surname,
+      ...rest,
+    });
+
+    await update<IDbUser>(headers, ['users', id], verifiedData);
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -3,6 +3,7 @@ import { IDbTeam, IDbUser, ITeam, IUser } from '../../db-types';
 import { TeamSchema, UserSchema } from '../../validator';
 import { PassedHeaders } from '../serverApp';
 import { create, getRecords, update, remove } from './operations';
+import { getUser } from '../auth';
 
 export const getUsers = async (headers: PassedHeaders) => {
   try {
@@ -35,6 +36,30 @@ export const pushUser = async (headers: PassedHeaders, data: IUser) => {
     });
 
     await update<IDbUser>(headers, ['users', id], verifiedData);
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const pushTheme = async (
+  headers: PassedHeaders,
+  data: 'light' | 'dark' | null
+) => {
+  const user = await getUser(headers);
+
+  console.log({ user });
+
+  if (!user.currentUser?.id) {
+    throw new Error('Missing user id');
+  }
+
+  try {
+    await update<Pick<IUser, 'theme'>>(
+      headers,
+      `users/${user.currentUser.id}`,
+      { theme: data }
+    );
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -1,10 +1,39 @@
-import { IDbUser } from '../../db-types';
+import * as z from 'zod';
+import { ITeam, IUser } from '../../db-types';
+import { TeamSchema, UserSchema } from '../../validator';
 import { PassedHeaders } from '../serverApp';
-import { get } from './operations';
+import { getRecords } from './operations';
 
 export const getUsers = async (headers: PassedHeaders) => {
   try {
-    const records = await get<IDbUser>(headers, 'users');
+    const records = await getRecords<IUser>(headers, 'users', (dbUser) => {
+      const record = UserSchema.extend({
+        id: z.string(),
+      }).parse(dbUser);
+      const { cognome, nome, ...rest } = record;
+      return {
+        name: nome,
+        surname: cognome,
+        ...rest,
+      };
+    });
+
+    return records;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const getTeams = async (headers: PassedHeaders) => {
+  try {
+    const records = await getRecords<ITeam>(headers, 'teams', (dbTeam) => {
+      const record = TeamSchema.extend({
+        id: z.string(),
+      }).parse(dbTeam);
+
+      return record;
+    });
 
     return records;
   } catch (e) {

--- a/src/services/firebase/server/firestore/operations.ts
+++ b/src/services/firebase/server/firestore/operations.ts
@@ -7,6 +7,7 @@ import {
   getDocs,
   getFirestore,
   QueryDocumentSnapshot,
+  UpdateData,
   updateDoc,
   WithFieldValue,
 } from 'firebase/firestore';
@@ -48,15 +49,17 @@ export const getRecords = async <Type extends DocumentData>(
 export const update = async <Type extends DocumentData>(
   headers: PassedHeaders,
   address: string | string[],
-  data: Type,
+  data: UpdateData<Type>,
   dto?: (dbData: DocumentData) => Type
 ) => {
   const firebaseServerApp = await getApp(headers);
   const db = getFirestore(firebaseServerApp);
   const fullAddress = typeof address === 'string' ? [address] : address;
+  // doc typing is a bit dumb, so we gotta do this
+  const [first, ...rest] = fullAddress;
 
   try {
-    const docToUpdate = doc(db, ...fullAddress).withConverter(
+    const docToUpdate = doc(db, first, ...rest).withConverter(
       converter<Type>(dto)
     );
 

--- a/src/services/firebase/server/firestore/operations.ts
+++ b/src/services/firebase/server/firestore/operations.ts
@@ -1,9 +1,11 @@
 import {
   collection,
+  doc,
   DocumentData,
   getDocs,
   getFirestore,
   QueryDocumentSnapshot,
+  setDoc,
   WithFieldValue,
 } from 'firebase/firestore';
 
@@ -41,21 +43,26 @@ export const getRecords = async <Type extends DocumentData>(
   return data;
 };
 
-// export const update = async <DbType extends DocumentData>(
-//   headers: PassedHeaders,
-//   address: string | string[],
-//   data: DbType
-// ) => {
-//   const firebaseServerApp = await getApp(headers);
-//   const db = getFirestore(firebaseServerApp);
-//   const fullAddress = typeof address === 'string' ? [address] : address;
+export const update = async <Type extends DocumentData>(
+  headers: PassedHeaders,
+  address: string | string[],
+  data: Type,
+  dto?: (dbData: DocumentData) => Type
+) => {
+  const firebaseServerApp = await getApp(headers);
+  const db = getFirestore(firebaseServerApp);
+  const fullAddress = typeof address === 'string' ? [address] : address;
 
-//   try {
-//     await setDoc<DbType, DbType>(doc(db, ...fullAddress), data);
-//   } catch (e) {
-//     throw e;
-//   }
-// };
+  try {
+    const docToUpdate = doc(db, ...fullAddress).withConverter(
+      converter<Type>(dto)
+    );
+
+    await setDoc(docToUpdate, data);
+  } catch (e) {
+    throw e;
+  }
+};
 
 // export const create = async <DbType extends DocumentData>(
 //   headers: PassedHeaders,

--- a/src/services/firebase/server/firestore/operations.ts
+++ b/src/services/firebase/server/firestore/operations.ts
@@ -1,0 +1,61 @@
+import {
+  addDoc,
+  collection,
+  doc,
+  DocumentData,
+  getDocs,
+  getFirestore,
+  setDoc,
+} from 'firebase/firestore';
+
+import { getApp, PassedHeaders } from '../serverApp';
+
+export const get = async <DbType extends DocumentData>(
+  currentHeaders: PassedHeaders,
+  address: string
+) => {
+  const firebaseServerApp = await getApp(currentHeaders);
+  const db = getFirestore(firebaseServerApp);
+
+  const querySnapshot = await getDocs<DbType, DbType>(collection(db, address));
+
+  const data: DbType[] = [];
+
+  querySnapshot.forEach((doc) => {
+    data.push(doc.data());
+  });
+
+  return data;
+};
+
+export const update = async <DbType extends DocumentData>(
+  headers: PassedHeaders,
+  address: string | string[],
+  data: DbType
+) => {
+  const firebaseServerApp = await getApp(headers);
+  const db = getFirestore(firebaseServerApp);
+  const fullAddress = typeof address === 'string' ? [address] : address;
+
+  try {
+    await setDoc<DbType, DbType>(doc(db, ...fullAddress), data);
+  } catch (e) {
+    throw e;
+  }
+};
+export const create = async <DbType extends DocumentData>(
+  headers: PassedHeaders,
+  address: string,
+  data: DbType
+) => {
+  const firebaseServerApp = await getApp(headers);
+  const db = getFirestore(firebaseServerApp);
+
+  try {
+    const docRef = await addDoc<DbType, DbType>(collection(db, address), data);
+
+    return docRef;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/services/firebase/server/firestore/operations.ts
+++ b/src/services/firebase/server/firestore/operations.ts
@@ -7,7 +7,7 @@ import {
   getDocs,
   getFirestore,
   QueryDocumentSnapshot,
-  setDoc,
+  updateDoc,
   WithFieldValue,
 } from 'firebase/firestore';
 
@@ -60,7 +60,7 @@ export const update = async <Type extends DocumentData>(
       converter<Type>(dto)
     );
 
-    await setDoc(docToUpdate, data);
+    await updateDoc(docToUpdate, data);
   } catch (e) {
     throw e;
   }

--- a/src/services/firebase/server/firestore/operations.ts
+++ b/src/services/firebase/server/firestore/operations.ts
@@ -1,5 +1,7 @@
 import {
+  addDoc,
   collection,
+  deleteDoc,
   doc,
   DocumentData,
   getDocs,
@@ -64,19 +66,43 @@ export const update = async <Type extends DocumentData>(
   }
 };
 
-// export const create = async <DbType extends DocumentData>(
-//   headers: PassedHeaders,
-//   address: string,
-//   data: DbType
-// ) => {
-//   const firebaseServerApp = await getApp(headers);
-//   const db = getFirestore(firebaseServerApp);
+export const create = async <Type extends DocumentData>(
+  headers: PassedHeaders,
+  address: string,
+  data: Type,
+  dto?: (dbData: DocumentData) => Type
+) => {
+  const firebaseServerApp = await getApp(headers);
+  const db = getFirestore(firebaseServerApp);
 
-//   try {
-//     const docRef = await addDoc<DbType, DbType>(collection(db, address), data);
+  try {
+    const collectionRef = collection(db, address).withConverter(
+      converter<Type>(dto)
+    );
 
-//     return docRef;
-//   } catch (e) {
-//     throw e;
-//   }
-// };
+    const docRef = await addDoc(collectionRef, data);
+
+    return docRef;
+  } catch (e) {
+    throw e;
+  }
+};
+
+export const remove = async (
+  headers: PassedHeaders,
+  address: string,
+  id: string
+) => {
+  const firebaseServerApp = await getApp(headers);
+  const db = getFirestore(firebaseServerApp);
+
+  try {
+    const docToDelete = doc(db, address, id);
+
+    const docRef = await deleteDoc(docToDelete);
+
+    return docRef;
+  } catch (e) {
+    throw e;
+  }
+};

--- a/src/services/firebase/server/index.ts
+++ b/src/services/firebase/server/index.ts
@@ -1,2 +1,3 @@
 export * from './db';
 export * from './auth';
+export * from './firestore';

--- a/src/services/firebase/validator.ts
+++ b/src/services/firebase/validator.ts
@@ -1,0 +1,24 @@
+import * as z from 'zod';
+
+export const UserSchema = z.object({
+  nome: z.string(),
+  cognome: z.string(),
+  email: z.string(),
+  isAdmin: z.boolean(),
+  scopes: z.optional(
+    z.object({
+      gmb: z.optional(z.boolean()),
+      config: z.optional(
+        z.object({
+          transport: z.optional(z.boolean()),
+        })
+      ),
+    })
+  ),
+  theme: z.optional(z.enum(['light', 'dark'])),
+  teams: z.optional(z.array(z.string())),
+});
+
+export const TeamSchema = z.object({
+  name: z.string(),
+});

--- a/src/services/firebase/validator.ts
+++ b/src/services/firebase/validator.ts
@@ -15,7 +15,7 @@ export const UserSchema = z.object({
       ),
     })
   ),
-  theme: z.optional(z.enum(['light', 'dark'])),
+  theme: z.optional(z.nullable(z.enum(['light', 'dark']))),
   teams: z.optional(z.array(z.string())),
 });
 


### PR DESCRIPTION
This PR adds the ability to view and update teams, including adding teams to users.
In order to do so, we switched to using Firestore as it seems more indicated for our future use cases.

## Changes

- add get users operation
- feat(Auth): switch to using firestore
- feat: add zod
- feat(FireStore): add user and teams
- feat(admin/users): add page and form
- feat(MultiSelect): add component
- feat(user-form): update user teams
- feat(team-form): add teams form
- feat(theme-toggle): update to use firestore
- fix(validator): add null theme
- feat(header): add nav item