### PR TITLE
feature: add teams for links

### DIFF
--- a/src/app/(protected)/(with-header)/admin/page.tsx
+++ b/src/app/(protected)/(with-header)/admin/page.tsx
@@ -9,10 +9,10 @@ import {
   getTvText,
   getLinksWithoutCache,
   getConfigWithoutCache,
+  getTeams,
 } from '@/services/firebase/server';
 import { TvForm } from '@/components/tv-form/tv-form';
 import { LinkForm } from '@/components/link-form/link-form';
-import { EColor } from '@/services/firebase/db-types';
 import { QuoteForm } from '@/components/quote-form/quote-form';
 import template from '../header-template.module.css';
 import { ConfigForm } from '@/components/config-form/config-form';
@@ -29,11 +29,12 @@ export default async function Admin() {
   const isAdmin = currentUser?.isAdmin;
   const canEditTransport = currentUser?.scopes?.config?.transport;
 
-  const [links, quote, tvText, config] = await Promise.all([
+  const [links, quote, tvText, config, teams] = await Promise.all([
     getLinksWithoutCache(currentHeaders),
     isAdmin ? getQuoteWithImages(currentHeaders) : undefined,
     getTvText(currentHeaders),
     getConfigWithoutCache(currentHeaders),
+    getTeams(currentHeaders),
   ]);
 
   if (!isAdmin && !canEditTransport) {
@@ -52,16 +53,17 @@ export default async function Admin() {
               <h2>Link</h2>
               <div className={styles.linksContainer}>
                 {links.map((link) => (
-                  <LinkForm key={link.id} link={link} />
+                  <LinkForm key={link.id} link={link} availableTeams={teams} />
                 ))}
                 <LinkForm
                   link={{
                     description: '',
                     link: '',
                     id: '',
-                    color: EColor.amber,
+                    teams: [],
                   }}
                   isNew
+                  availableTeams={teams}
                 />
               </div>
             </div>

--- a/src/components/link-form/link-action.ts
+++ b/src/components/link-form/link-action.ts
@@ -5,7 +5,6 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 
 import { FORM_FAIL_LINK, FORM_SUCCESS_LINK } from '@/consts';
 import { createLink, deleteLink, pushLink } from '@/services/firebase/server';
-import { EColor } from '@/services/firebase/db-types';
 
 export type StateValidation = {
   error?: string;
@@ -20,8 +19,9 @@ export const linkAction = async (_: StateValidation, values: FormData) => {
     const formLink = values.get('link');
     const formId = values.get('id');
     const formIsNew = values.get('isNew');
+    const formTeams = values.getAll('teams');
 
-    if (!formDescription || !formLink) {
+    if (!formDescription || !formLink || !formTeams) {
       return {
         error: FORM_FAIL_LINK,
       };
@@ -39,19 +39,20 @@ export const linkAction = async (_: StateValidation, values: FormData) => {
     const link = String(formLink);
     const id = String(formId);
     const isNew = String(formIsNew) === 'NEW';
+    const teams = formTeams.map((team) => String(team));
 
     if (isNew && !id) {
       await createLink(currentHeaders, {
         description,
         link,
-        color: EColor.amber,
+        teams,
       });
     } else {
       await pushLink(currentHeaders, {
         description,
         link,
         id,
-        color: EColor.amber,
+        teams,
       });
     }
 
@@ -79,9 +80,7 @@ export const linkDeleteAction = async (id: string) => {
       throw new Error('No id provided');
     }
 
-    await deleteLink(currentHeaders, {
-      id,
-    });
+    await deleteLink(currentHeaders, id);
 
     revalidatePath('/admin');
     revalidateTag('links');

--- a/src/components/link-form/link-form.tsx
+++ b/src/components/link-form/link-form.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState } from 'react';
 
-import type { ICleanLink, ITeam } from '@/services/firebase/db-types';
+import type { ILink, ITeam } from '@/services/firebase/db-types';
 import { linkAction, linkDeleteAction, StateValidation } from './link-action';
 import styles from './link-form.module.css';
 import { FormStatus } from '../form-status/form-status';
@@ -11,7 +11,7 @@ import { SaveIcon } from '../icons/save';
 import { MultiSelect } from '../multiselect/multiselect';
 
 type LinksFormProps = {
-  link: ICleanLink;
+  link: ILink;
   isNew?: boolean;
   availableTeams: ITeam[];
 };

--- a/src/components/link-form/link-form.tsx
+++ b/src/components/link-form/link-form.tsx
@@ -2,24 +2,33 @@
 
 import { useActionState } from 'react';
 
-import type { ILink } from '@/services/firebase/db-types';
+import type { ICleanLink, ITeam } from '@/services/firebase/db-types';
 import { linkAction, linkDeleteAction, StateValidation } from './link-action';
 import styles from './link-form.module.css';
 import { FormStatus } from '../form-status/form-status';
 import { DeleteIcon } from '../icons/delete';
 import { SaveIcon } from '../icons/save';
+import { MultiSelect } from '../multiselect/multiselect';
 
 type LinksFormProps = {
-  link: ILink;
+  link: ICleanLink;
   isNew?: boolean;
+  availableTeams: ITeam[];
 };
 const initialState: StateValidation = {};
 
 export const LinkForm = ({
-  link: { description, link, id },
+  link: { description, link, id, teams },
   isNew = false,
+  availableTeams,
 }: LinksFormProps) => {
   const [state, formAction, pending] = useActionState(linkAction, initialState);
+
+  const selectTeams = availableTeams.map((team) => ({
+    value: team.id,
+    label: team.name,
+    isDefaultChecked: !!teams?.some((current) => current === team.id),
+  }));
 
   return (
     <form action={formAction}>
@@ -32,6 +41,9 @@ export const LinkForm = ({
           Link
           <input type="url" name="link" defaultValue={link} required />
         </label>
+        <div className={styles.selectContainer}>
+          <MultiSelect options={selectTeams} name="teams" legend="Teams" />
+        </div>
         <input type="hidden" name="id" value={id} />
         <input type="hidden" name="isNew" value={isNew ? 'NEW' : ''} />
         <div className={styles.buttonsContainer}>

--- a/src/components/links/links.tsx
+++ b/src/components/links/links.tsx
@@ -1,8 +1,8 @@
-import { ICleanLink } from '@/services/firebase/db-types';
+import { ILink } from '@/services/firebase/db-types';
 import styles from './links.module.css';
 
 interface ILinkProps {
-  links: ICleanLink[];
+  links: ILink[];
 }
 
 export const Links: React.FC<ILinkProps> = ({ links }) => {

--- a/src/components/links/links.tsx
+++ b/src/components/links/links.tsx
@@ -1,8 +1,8 @@
-import { ILink } from '@/services/firebase/db-types';
+import { ICleanLink } from '@/services/firebase/db-types';
 import styles from './links.module.css';
 
 interface ILinkProps {
-  links: ILink[];
+  links: ICleanLink[];
 }
 
 export const Links: React.FC<ILinkProps> = ({ links }) => {
@@ -13,12 +13,8 @@ export const Links: React.FC<ILinkProps> = ({ links }) => {
       </div>
       <ul className={styles.list}>
         {links &&
-          links.map(({ link, description, color }) => (
-            <li
-              style={{ borderInlineStartColor: color }}
-              data-testid={color === 'test' ? 'test-link' : ''}
-              key={link}
-            >
+          links.map(({ link, description }) => (
+            <li key={link}>
               <a
                 href={link}
                 className={styles.link}

--- a/src/services/firebase/db-types.ts
+++ b/src/services/firebase/db-types.ts
@@ -54,6 +54,19 @@ export interface ILink {
   link: string;
 }
 
+export interface ICleanDbLink {
+  description: string;
+  id: string;
+  link: string;
+  teams?: string[];
+}
+export interface ICleanLink {
+  description: string;
+  id: string;
+  link: string;
+  teams?: string[];
+}
+
 export interface IQuote {
   text: string;
   url: string;

--- a/src/services/firebase/db-types.ts
+++ b/src/services/firebase/db-types.ts
@@ -38,13 +38,13 @@ export interface ITeam {
   id: string;
 }
 
-export interface ICleanDbLink {
+export interface IDbLink {
   description: string;
   id: string;
   link: string;
   teams: string[];
 }
-export interface ICleanLink {
+export interface ILink {
   description: string;
   id: string;
   link: string;

--- a/src/services/firebase/db-types.ts
+++ b/src/services/firebase/db-types.ts
@@ -38,33 +38,17 @@ export interface ITeam {
   id: string;
 }
 
-export interface IDbLinks {
-  [id: string]: {
-    color: EColor;
-    description: string;
-    id: string;
-    link: string;
-  };
-}
-
-export interface ILink {
-  color: EColor;
-  description: string;
-  id: string;
-  link: string;
-}
-
 export interface ICleanDbLink {
   description: string;
   id: string;
   link: string;
-  teams?: string[];
+  teams: string[];
 }
 export interface ICleanLink {
   description: string;
   id: string;
   link: string;
-  teams?: string[];
+  teams: string[];
 }
 
 export interface IQuote {
@@ -111,15 +95,3 @@ export type IConfig = {
   transportCostMinimum: number;
   transportHourBase: number;
 };
-
-export enum EColor {
-  grey = 'grey',
-  deepOrange = 'deepOrange',
-  amber = 'amber',
-  green = 'green',
-  teal = 'teal',
-  lightBlue = 'lightBlue',
-  indigo = 'indigo',
-  red = 'red',
-  test = 'test',
-}

--- a/src/services/firebase/server/db/index.ts
+++ b/src/services/firebase/server/db/index.ts
@@ -2,19 +2,17 @@ import { unstable_cache } from 'next/cache';
 
 import {
   IDbImage,
-  IDbLinks,
   type IConfig,
   type IDbConfig,
   type IDbTv,
   type IGoogleAuth,
   type IImage,
-  type ILink,
   type IQuote,
   type ITv,
 } from '../../db-types';
 import { normaliseObjectKeysToArray } from '@/utils/normaliseObjectKeysToArray';
 import { type PassedHeaders } from '../serverApp';
-import { create, get, remove, update } from './operations';
+import { get, update } from './operations';
 import { getUser } from '../auth';
 
 const SHORT_CACHE = 60 * 60; // one hour
@@ -39,24 +37,6 @@ export const getConfigWithoutCache = async (headers: PassedHeaders) => {
 export const getConfig = unstable_cache(getConfigWithoutCache, ['config'], {
   revalidate: SHORT_CACHE,
   tags: ['config'],
-});
-
-export const getLinksWithoutCache = async (headers: PassedHeaders) => {
-  try {
-    const records = await get<IDbLinks>(headers, 'links');
-
-    const data: ILink[] = normaliseObjectKeysToArray(records);
-
-    return data;
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
-};
-
-export const getLinks = unstable_cache(getLinksWithoutCache, ['links'], {
-  revalidate: LONG_CACHE,
-  tags: ['links'],
 });
 
 export const getQuote = unstable_cache(
@@ -135,15 +115,6 @@ export const pushTv = async (headers: PassedHeaders, data: IDbTv) => {
   }
 };
 
-export const pushLink = async (headers: PassedHeaders, data: ILink) => {
-  try {
-    await update(headers, `links/${data.id}`, data);
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
-};
-
 export const pushConfig = async (
   headers: PassedHeaders,
   data: Partial<IDbConfig>
@@ -173,29 +144,6 @@ export const pushGoogleAuth = async (
     await update(headers, 'googleAuth/active', data);
   } catch (e) {
     console.error(e);
-    throw e;
-  }
-};
-
-export const createLink = async (
-  headers: PassedHeaders,
-  data: Omit<ILink, 'id'>
-) => {
-  try {
-    await create(headers, 'links', data);
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
-};
-
-export const deleteLink = async (
-  headers: PassedHeaders,
-  data: Pick<ILink, 'id'>
-) => {
-  try {
-    await remove(headers, 'links', data.id);
-  } catch (e) {
     throw e;
   }
 };

--- a/src/services/firebase/server/db/operations.ts
+++ b/src/services/firebase/server/db/operations.ts
@@ -2,9 +2,7 @@ import {
   child,
   get as firebaseGet,
   getDatabase,
-  push as firebasePush,
   ref,
-  remove as firebaseRemove,
   update as firebaseUpdate,
 } from 'firebase/database';
 
@@ -38,42 +36,4 @@ export const update = async <DataType extends object>(
   const dbRef = ref(db);
 
   await firebaseUpdate(child(dbRef, address), data);
-};
-
-export const create = async <DbType>(
-  headers: PassedHeaders,
-  address: string,
-  data: DbType
-) => {
-  const firebaseServerApp = await getApp(headers);
-  const db = getDatabase(firebaseServerApp);
-  const dbRef = ref(db);
-
-  try {
-    const newPostKey = firebasePush(child(dbRef, address)).key;
-
-    const postData = {
-      ...data,
-      id: newPostKey,
-    };
-
-    await firebaseUpdate(ref(db, `${address}/${newPostKey}`), postData);
-  } catch (e) {
-    throw e;
-  }
-};
-
-export const remove = async (
-  headers: PassedHeaders,
-  address: string,
-  id: string
-) => {
-  const firebaseServerApp = await getApp(headers);
-  const db = getDatabase(firebaseServerApp);
-
-  try {
-    await firebaseRemove(ref(db, `${address}/${id}`));
-  } catch (e) {
-    throw e;
-  }
 };

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -155,9 +155,16 @@ export const createLink = async (
   data: Omit<ILink, 'id'>
 ) => {
   try {
-    const verifiedData = LinkSchema.parse(data);
+    const verifiedData = LinkSchema.omit({ id: true }).parse(data);
 
-    await create<IDbLink>(headers, 'links', verifiedData);
+    const createdDoc = await create<Omit<ILink, 'id'>>(
+      headers,
+      'links',
+      verifiedData
+    );
+    await update<IDbLink>(headers, ['links', createdDoc.id], {
+      id: createdDoc.id,
+    });
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -1,14 +1,7 @@
 import * as z from 'zod';
 import { unstable_cache } from 'next/cache';
 
-import {
-  ICleanDbLink,
-  ICleanLink,
-  IDbTeam,
-  IDbUser,
-  ITeam,
-  IUser,
-} from '../../db-types';
+import { IDbLink, ILink, IDbTeam, IDbUser, ITeam, IUser } from '../../db-types';
 import { LinkSchema, TeamSchema, UserSchema } from '../../validator';
 import { PassedHeaders } from '../serverApp';
 import { create, getRecords, update, remove } from './operations';
@@ -128,7 +121,7 @@ export const deleteTeam = async (headers: PassedHeaders, id: string) => {
 
 export const getLinksWithoutCache = async (headers: PassedHeaders) => {
   try {
-    const records = await getRecords<ICleanLink>(headers, 'links', (dbTeam) => {
+    const records = await getRecords<ILink>(headers, 'links', (dbTeam) => {
       const record = LinkSchema.parse(dbTeam);
 
       return record;
@@ -146,11 +139,11 @@ export const getLinks = unstable_cache(getLinksWithoutCache, ['links'], {
   tags: ['links'],
 });
 
-export const pushLink = async (headers: PassedHeaders, data: ICleanDbLink) => {
+export const pushLink = async (headers: PassedHeaders, data: IDbLink) => {
   try {
     const verifiedData = LinkSchema.parse(data);
 
-    await update<ICleanDbLink>(headers, ['links', data.id], verifiedData);
+    await update<IDbLink>(headers, ['links', data.id], verifiedData);
   } catch (e) {
     console.error(e);
     throw e;
@@ -159,12 +152,12 @@ export const pushLink = async (headers: PassedHeaders, data: ICleanDbLink) => {
 
 export const createLink = async (
   headers: PassedHeaders,
-  data: Omit<ICleanLink, 'id'>
+  data: Omit<ILink, 'id'>
 ) => {
   try {
     const verifiedData = LinkSchema.parse(data);
 
-    await create<ICleanDbLink>(headers, 'links', verifiedData);
+    await create<IDbLink>(headers, 'links', verifiedData);
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -1,6 +1,13 @@
 import * as z from 'zod';
-import { IDbTeam, IDbUser, ITeam, IUser } from '../../db-types';
-import { TeamSchema, UserSchema } from '../../validator';
+import {
+  ICleanDbLink,
+  ICleanLink,
+  IDbTeam,
+  IDbUser,
+  ITeam,
+  IUser,
+} from '../../db-types';
+import { LinkSchema, TeamSchema, UserSchema } from '../../validator';
 import { PassedHeaders } from '../serverApp';
 import { create, getRecords, update, remove } from './operations';
 import { getUser } from '../auth';
@@ -109,6 +116,32 @@ export const createTeam = async (headers: PassedHeaders, data: IDbTeam) => {
 export const deleteTeam = async (headers: PassedHeaders, id: string) => {
   try {
     await remove(headers, 'teams', id);
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const getLinks = async (headers: PassedHeaders) => {
+  try {
+    const records = await getRecords<ICleanLink>(headers, 'links', (dbTeam) => {
+      const record = LinkSchema.parse(dbTeam);
+
+      return record;
+    });
+
+    return records;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
+export const pushLink = async (headers: PassedHeaders, data: ICleanDbLink) => {
+  try {
+    const verifiedData = LinkSchema.parse(data);
+
+    await update<ICleanDbLink>(headers, ['links', data.id], verifiedData);
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/services/firebase/validator.ts
+++ b/src/services/firebase/validator.ts
@@ -22,3 +22,10 @@ export const UserSchema = z.object({
 export const TeamSchema = z.object({
   name: z.string(),
 });
+
+export const LinkSchema = z.object({
+  description: z.string(),
+  link: z.url(),
+  id: z.string(),
+  teams: z.array(z.string()),
+});


### PR DESCRIPTION
This PR updates links to use Firestore, so we can assign teams to them, in preparation for locking down the shown links relative to a user's team.

## Changes

- feat(links): add firestore links
- feat(links): switch all to firestore