### PR TITLE
feature: show only team links

### DIFF
--- a/src/app/(protected)/(with-header)/page.tsx
+++ b/src/app/(protected)/(with-header)/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 import { Quote } from '@/components/quote/quote';
 import { WelcomeMessage } from '@/components/welcome-message/welcome-message';
 import { Links } from '@/components/links/links';
-import { getUser, getLinks, getQuote } from '@/services/firebase/server';
+import { getUser, getQuote, getLinksForTeam } from '@/services/firebase/server';
 import template from './header-template.module.css';
 import styles from './page.module.css';
 
@@ -22,7 +22,7 @@ export default async function Home() {
   }
 
   const [links, quote] = await Promise.all([
-    getLinks(currentHeaders),
+    getLinksForTeam(currentHeaders, currentUser.teams || ['']),
     getQuote(currentHeaders),
   ]);
 

--- a/src/components/link-form/link-action.ts
+++ b/src/components/link-form/link-action.ts
@@ -46,7 +46,7 @@ export const linkAction = async (_: StateValidation, values: FormData) => {
     const icon = formIcon instanceof File ? formIcon : undefined;
     let iconUpload: string | undefined = undefined;
 
-    if (icon) {
+    if (icon && icon.size > 0) {
       const uploadFileUrl = await uploadLinkIcon(currentHeaders, icon);
       iconUpload = uploadFileUrl;
     }
@@ -56,7 +56,7 @@ export const linkAction = async (_: StateValidation, values: FormData) => {
         description,
         link,
         teams,
-        icon: iconUpload,
+        ...(iconUpload ? { icon: iconUpload } : {}),
       });
     } else {
       await pushLink(currentHeaders, {
@@ -64,7 +64,7 @@ export const linkAction = async (_: StateValidation, values: FormData) => {
         link,
         id,
         teams,
-        icon: iconUpload,
+        ...(iconUpload ? { icon: iconUpload } : {}),
       });
     }
 

--- a/src/components/link-form/link-action.ts
+++ b/src/components/link-form/link-action.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { headers } from 'next/headers';
-import { revalidatePath, revalidateTag } from 'next/cache';
+import { revalidatePath } from 'next/cache';
 
 import { FORM_FAIL_LINK, FORM_SUCCESS_LINK } from '@/consts';
 import { createLink, deleteLink, pushLink } from '@/services/firebase/server';
@@ -69,7 +69,6 @@ export const linkAction = async (_: StateValidation, values: FormData) => {
     }
 
     revalidatePath('/admin');
-    revalidateTag('links');
 
     return {
       success: FORM_SUCCESS_LINK,
@@ -95,7 +94,6 @@ export const linkDeleteAction = async (id: string) => {
     await deleteLink(currentHeaders, id);
 
     revalidatePath('/admin');
-    revalidateTag('links');
   } catch (e) {
     console.error(e);
     throw e;

--- a/src/components/user-form/user-action.ts
+++ b/src/components/user-form/user-action.ts
@@ -44,7 +44,6 @@ export const userAction = async (
     });
 
     revalidatePath('/admin/users');
-    // do we need this? revalidateTag('links');
 
     return {
       success: FORM_SUCCESS_USER,

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -4,7 +4,13 @@ import { unstable_cache } from 'next/cache';
 import { IDbLink, ILink, IDbTeam, IDbUser, ITeam, IUser } from '../../db-types';
 import { LinkSchema, TeamSchema, UserSchema } from '../../validator';
 import { PassedHeaders } from '../serverApp';
-import { create, getRecords, update, remove } from './operations';
+import {
+  create,
+  getRecords,
+  update,
+  remove,
+  getRecordsWhereArrayToArray,
+} from './operations';
 import { getUser } from '../auth';
 
 const LONG_CACHE = 60 * 60 * 24 * 7; // one week
@@ -138,6 +144,32 @@ export const getLinks = unstable_cache(getLinksWithoutCache, ['links'], {
   revalidate: LONG_CACHE,
   tags: ['links'],
 });
+
+export const getLinksForTeam = async (
+  headers: PassedHeaders,
+  teams: string[]
+) => {
+  try {
+    const records = await getRecordsWhereArrayToArray<ILink>(
+      headers,
+      'links',
+      {
+        field: 'teams',
+        array: teams,
+      },
+      (dbTeam) => {
+        const record = LinkSchema.parse(dbTeam);
+
+        return record;
+      }
+    );
+
+    return records;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
 
 export const pushLink = async (headers: PassedHeaders, data: IDbLink) => {
   try {

--- a/src/services/firebase/server/firestore/index.ts
+++ b/src/services/firebase/server/firestore/index.ts
@@ -1,5 +1,4 @@
 import * as z from 'zod';
-import { unstable_cache } from 'next/cache';
 
 import { IDbLink, ILink, IDbTeam, IDbUser, ITeam, IUser } from '../../db-types';
 import { LinkSchema, TeamSchema, UserSchema } from '../../validator';
@@ -12,8 +11,6 @@ import {
   getRecordsWhereArrayToArray,
 } from './operations';
 import { getUser } from '../auth';
-
-const LONG_CACHE = 60 * 60 * 24 * 7; // one week
 
 export const getUsers = async (headers: PassedHeaders) => {
   try {
@@ -139,11 +136,6 @@ export const getLinksWithoutCache = async (headers: PassedHeaders) => {
     throw e;
   }
 };
-
-export const getLinks = unstable_cache(getLinksWithoutCache, ['links'], {
-  revalidate: LONG_CACHE,
-  tags: ['links'],
-});
 
 export const getLinksForTeam = async (
   headers: PassedHeaders,

--- a/src/services/firebase/server/firestore/operations.ts
+++ b/src/services/firebase/server/firestore/operations.ts
@@ -6,9 +6,11 @@ import {
   DocumentData,
   getDocs,
   getFirestore,
+  query,
   QueryDocumentSnapshot,
   UpdateData,
   updateDoc,
+  where,
   WithFieldValue,
 } from 'firebase/firestore';
 
@@ -36,6 +38,35 @@ export const getRecords = async <Type extends DocumentData>(
   const querySnapshot = await getDocs(
     collection(db, address).withConverter(converter<Type>(dto))
   );
+
+  const data: Type[] = [];
+
+  querySnapshot.forEach((doc) => {
+    data.push(doc.data());
+  });
+
+  return data;
+};
+
+export const getRecordsWhereArrayToArray = async <Type extends DocumentData>(
+  currentHeaders: PassedHeaders,
+  address: string,
+  queryData: { field: string; array: string[] },
+  dto?: (dbData: DocumentData) => Type
+) => {
+  const firebaseServerApp = await getApp(currentHeaders);
+  const db = getFirestore(firebaseServerApp);
+
+  const collectionRef = collection(db, address).withConverter(
+    converter<Type>(dto)
+  );
+
+  const q = query(
+    collectionRef,
+    where(queryData.field, 'array-contains-any', queryData.array)
+  );
+
+  const querySnapshot = await getDocs(q);
 
   const data: Type[] = [];
 


### PR DESCRIPTION
This PR updates the homepage links to show only the links for the users teams.

## Changes

- feat(Firestore): add query capability
- feat(homepage): switch to team query
- fix(LinkForm): pass file only if existing