### PR TITLE
chore: switch to permission scopes

### DIFF
--- a/src/app/(protected)/(with-header)/admin-google/page.tsx
+++ b/src/app/(protected)/(with-header)/admin-google/page.tsx
@@ -9,6 +9,7 @@ import { Business } from '@/components/google/business/business';
 import { IGoogleAuth } from '@/services/firebase/db-types';
 import styles from './page.module.css';
 import template from '../header-template.module.css';
+import { checkCanEditGMB } from '@/services/firebase/server/permissions';
 
 const manageGoogleAuth = async (googleAuth: IGoogleAuth | undefined) => {
   if (!googleAuth?.refresh_token) {
@@ -36,7 +37,7 @@ export default async function AdminGoogle() {
   const currentHeaders = await headers();
   const { currentUser } = await getUser(currentHeaders);
 
-  if (!currentUser?.isAdmin && !currentUser?.scopes?.gmb) {
+  if (!checkCanEditGMB(currentUser?.permissions)) {
     return redirect('/');
   }
 

--- a/src/app/(protected)/(with-header)/admin/page.tsx
+++ b/src/app/(protected)/(with-header)/admin/page.tsx
@@ -16,6 +16,10 @@ import { LinkForm } from '@/components/link-form/link-form';
 import { QuoteForm } from '@/components/quote-form/quote-form';
 import template from '../header-template.module.css';
 import { ConfigForm } from '@/components/config-form/config-form';
+import {
+  checkCanEditConfig,
+  checkIsAdmin,
+} from '@/services/firebase/server/permissions';
 
 export const metadata: Metadata = {
   title: 'Admin - Intranet Pieroni srl',
@@ -26,8 +30,8 @@ export default async function Admin() {
   const currentHeaders = await headers();
   const { currentUser } = await getUser(currentHeaders);
 
-  const isAdmin = currentUser?.isAdmin;
-  const canEditTransport = currentUser?.scopes?.config?.transport;
+  const isAdmin = checkIsAdmin(currentUser?.permissions);
+  const canEditConfig = checkCanEditConfig(currentUser?.permissions);
 
   const [links, quote, tvText, config, teams] = await Promise.all([
     getLinksWithoutCache(currentHeaders),
@@ -37,7 +41,7 @@ export default async function Admin() {
     getTeams(currentHeaders),
   ]);
 
-  if (!isAdmin && !canEditTransport) {
+  if (!canEditConfig) {
     return redirect('/');
   }
 
@@ -84,43 +88,41 @@ export default async function Admin() {
             </div>
           </>
         )}
-        {(canEditTransport || isAdmin) && (
-          <div className={styles.section}>
-            <h2>Configurazione</h2>
-            <ConfigForm>
-              {isAdmin && (
-                <label>
-                  Url mail
-                  <input name="mailUrl" defaultValue={config.mailUrl} />
-                </label>
-              )}
+        <div className={styles.section}>
+          <h2>Configurazione</h2>
+          <ConfigForm>
+            {isAdmin && (
               <label>
-                Costo trasporto al minuto
-                <input
-                  type="number"
-                  name="transportCostPerMinute"
-                  defaultValue={config.transportCostPerMinute}
-                />
+                Url mail
+                <input name="mailUrl" defaultValue={config.mailUrl} />
               </label>
-              <label>
-                Costo trasporto minimo
-                <input
-                  type="number"
-                  name="transportCostMinimum"
-                  defaultValue={config.transportCostMinimum}
-                />
-              </label>
-              <label>
-                Ore base trasporto
-                <input
-                  type="number"
-                  name="transportHourBase"
-                  defaultValue={config.transportHourBase}
-                />
-              </label>
-            </ConfigForm>
-          </div>
-        )}
+            )}
+            <label>
+              Costo trasporto al minuto
+              <input
+                type="number"
+                name="transportCostPerMinute"
+                defaultValue={config.transportCostPerMinute}
+              />
+            </label>
+            <label>
+              Costo trasporto minimo
+              <input
+                type="number"
+                name="transportCostMinimum"
+                defaultValue={config.transportCostMinimum}
+              />
+            </label>
+            <label>
+              Ore base trasporto
+              <input
+                type="number"
+                name="transportHourBase"
+                defaultValue={config.transportHourBase}
+              />
+            </label>
+          </ConfigForm>
+        </div>
       </div>
     </main>
   );

--- a/src/app/(protected)/(with-header)/admin/users/page.tsx
+++ b/src/app/(protected)/(with-header)/admin/users/page.tsx
@@ -8,6 +8,7 @@ import template from '../../header-template.module.css';
 import { UserForm } from '@/components/user-form/user-form';
 import { getTeams, getUsers } from '@/services/firebase/server';
 import { TeamForm } from '@/components/team-form/team-form';
+import { checkIsAdmin } from '@/services/firebase/server/permissions';
 
 export const metadata: Metadata = {
   title: 'Admin utenti - Intranet Pieroni srl',
@@ -18,7 +19,7 @@ export default async function Admin() {
   const currentHeaders = await headers();
   const { currentUser } = await getUser(currentHeaders);
 
-  const isAdmin = currentUser?.isAdmin;
+  const isAdmin = checkIsAdmin(currentUser?.permissions);
 
   const [users, teams] = await Promise.all([
     getUsers(currentHeaders),

--- a/src/app/(protected)/(with-header)/layout.tsx
+++ b/src/app/(protected)/(with-header)/layout.tsx
@@ -26,8 +26,7 @@ export default async function RootLayout({
         {currentUser && (
           <Header
             mailUrl={config.mailUrl}
-            isAdmin={currentUser.isAdmin}
-            scopes={currentUser.scopes}
+            permissions={currentUser.permissions}
             theme={currentUser.theme}
           />
         )}
@@ -37,8 +36,7 @@ export default async function RootLayout({
         {currentUser && (
           <HeaderModal
             mailUrl={config.mailUrl}
-            isAdmin={currentUser.isAdmin}
-            scopes={currentUser.scopes}
+            permissions={currentUser.permissions}
             theme={currentUser.theme}
           />
         )}

--- a/src/app/(protected)/(with-header)/riscossi/[id]/page.tsx
+++ b/src/app/(protected)/(with-header)/riscossi/[id]/page.tsx
@@ -8,6 +8,7 @@ import { RiscossiForm } from '@/components/riscosso-form/riscosso-form';
 import { PrintButton } from '@/components/print-button/print-button';
 import { formatDate } from '@/utils/formatDate';
 import { RiscossoCheck } from '@/components/riscosso-form/riscosso-check';
+import { checkCanEditRiscossi } from '@/services/firebase/server/permissions';
 
 export const metadata: Metadata = {
   title: 'Riscosso - Intranet Pieroni srl',
@@ -49,12 +50,11 @@ export default async function Riscossi({
     throw new Error('User not found');
   }
 
-  // check scope for riscossi
-  const isAdminUser = currentUser.isAdmin;
+  const canEditRiscossi = checkCanEditRiscossi(currentUser.permissions);
 
   const [riscosso, users] = await Promise.all([
     getRiscosso(currentHeaders, id),
-    isAdminUser ? getUsers(currentHeaders) : undefined,
+    canEditRiscossi ? getUsers(currentHeaders) : undefined,
   ]);
   const {
     company,
@@ -80,7 +80,7 @@ export default async function Riscossi({
       </div>
 
       <div className={styles.container}>
-        {isAdminUser && (
+        {canEditRiscossi && (
           <div className={`${styles.section} ${styles.noPrint}`}>
             <h2>Gestisci documento</h2>
             {isAlreadyChecked && (

--- a/src/app/(protected)/(with-header)/riscossi/admin/page.tsx
+++ b/src/app/(protected)/(with-header)/riscossi/admin/page.tsx
@@ -6,6 +6,7 @@ import template from '../../header-template.module.css';
 import { getRiscossi, getUser, getUsers } from '@/services/firebase/server';
 import { headers } from 'next/headers';
 import { formatDate } from '@/utils/formatDate';
+import { checkCanEditRiscossi } from '@/services/firebase/server/permissions';
 
 export const metadata: Metadata = {
   title: 'Gestisci riscossi - Intranet Pieroni srl',
@@ -22,10 +23,7 @@ export default async function Riscossi() {
   const currentHeaders = await headers();
   const { currentUser } = await getUser(currentHeaders);
 
-  if (
-    !currentUser?.isAdmin
-    // && !currentUser?.scopes?.gmb
-  ) {
+  if (!checkCanEditRiscossi(currentUser?.permissions)) {
     return redirect('/');
   }
 

--- a/src/app/(protected)/maps/page.tsx
+++ b/src/app/(protected)/maps/page.tsx
@@ -36,10 +36,9 @@ export default async function Maps() {
         <div className={styles.mobileMenuContainer}>
           {currentUser && (
             <HeaderModal
-              isAdmin={currentUser.isAdmin}
+              permissions={currentUser.permissions}
               mailUrl={config.mailUrl}
               theme={currentUser.theme}
-              scopes={currentUser.scopes}
             />
           )}
         </div>

--- a/src/app/(protected)/oauth2callback/route.tsx
+++ b/src/app/(protected)/oauth2callback/route.tsx
@@ -4,12 +4,13 @@ import { headers } from 'next/headers';
 
 import { googleClient } from '@/services/google-apis';
 import { pushGoogleAuth, getUser } from '@/services/firebase/server';
+import { checkIsAdmin } from '@/services/firebase/server/permissions';
 
 export async function GET(request: NextRequest) {
   const currentHeaders = await headers();
 
   const user = await getUser(currentHeaders);
-  if (!user.currentUser?.isAdmin) {
+  if (!checkIsAdmin(user.currentUser?.permissions)) {
     return Response.error();
   }
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -8,20 +8,20 @@ import styles from './header.module.css';
 import { ThemeToggle } from '../theme-toggle/theme-toggle';
 import { MenuIcon } from '../icons/menu';
 import { CloseIcon } from '../icons/close';
+import { IUser } from '@/services/firebase/db-types';
+import {
+  checkCanEditConfig,
+  checkCanEditGMB,
+  checkIsAdmin,
+} from '@/services/firebase/server/permissions';
 
 type HeaderProps = {
   mailUrl: string;
-  isAdmin: boolean;
-  scopes?: {
-    gmb?: boolean;
-    config?: {
-      transport?: boolean;
-    };
-  };
+  permissions: IUser['permissions'];
   theme?: 'light' | 'dark' | null;
 };
 
-export function Header({ mailUrl, isAdmin, scopes, theme }: HeaderProps) {
+export function Header({ mailUrl, theme, permissions }: HeaderProps) {
   const currentPath = usePathname();
 
   const getLinkProps = (href: string) => {
@@ -60,13 +60,15 @@ export function Header({ mailUrl, isAdmin, scopes, theme }: HeaderProps) {
           </a>
           <a {...getLinkProps('/maps')}>Costo trasporti</a>
           <a {...getLinkProps('/cartello')}>Crea cartello</a>
-          {(isAdmin || scopes?.gmb) && (
+          {checkCanEditGMB(permissions) && (
             <a {...getLinkProps('/admin-google')}>Gestisci Google</a>
           )}
-          {(isAdmin || scopes?.config?.transport) && (
+          {checkCanEditConfig(permissions) && (
             <a {...getLinkProps('/admin')}>Admin</a>
           )}
-          {isAdmin && <a {...getLinkProps('/admin/users')}>Utenti e team</a>}
+          {checkIsAdmin(permissions) && (
+            <a {...getLinkProps('/admin/users')}>Utenti e team</a>
+          )}
 
           <button className={styles.logOut} onClick={handleSignOut}>
             Esci

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -12,6 +12,7 @@ import { IUser } from '@/services/firebase/db-types';
 import {
   checkCanEditConfig,
   checkCanEditGMB,
+  checkCanEditRiscossi,
   checkIsAdmin,
 } from '@/services/firebase/server/permissions';
 
@@ -60,6 +61,10 @@ export function Header({ mailUrl, theme, permissions }: HeaderProps) {
           </a>
           <a {...getLinkProps('/maps')}>Costo trasporti</a>
           <a {...getLinkProps('/cartello')}>Crea cartello</a>
+          <a {...getLinkProps('/riscossi')}>Riscossi</a>
+          {checkCanEditRiscossi(permissions) && (
+            <a {...getLinkProps('/riscossi/admin')}>Gestione riscossi</a>
+          )}
           {checkCanEditGMB(permissions) && (
             <a {...getLinkProps('/admin-google')}>Gestisci Google</a>
           )}

--- a/src/services/firebase/db-types.ts
+++ b/src/services/firebase/db-types.ts
@@ -12,12 +12,6 @@ export interface IDbUser {
   cognome: string;
   email: string;
   isAdmin: boolean;
-  scopes?: {
-    gmb?: boolean;
-    config?: {
-      transport?: boolean;
-    };
-  };
   permissions?: UserScopes[];
   theme?: 'light' | 'dark' | null;
   teams?: string[];
@@ -29,12 +23,6 @@ export interface IUser {
   surname: string;
   email: string;
   isAdmin: boolean;
-  scopes?: {
-    gmb?: boolean;
-    config?: {
-      transport?: boolean;
-    };
-  };
   permissions?: UserScopes[];
   theme?: 'light' | 'dark' | null;
   teams?: string[];

--- a/src/services/firebase/db-types.ts
+++ b/src/services/firebase/db-types.ts
@@ -1,5 +1,12 @@
 import { Timestamp } from 'firebase/firestore';
 
+type UserScopes =
+  | 'read/riscossi'
+  | 'write/riscossi'
+  | 'write/gmb'
+  | 'write/config'
+  | 'admin';
+
 export interface IDbUser {
   nome: string;
   cognome: string;
@@ -11,6 +18,7 @@ export interface IDbUser {
       transport?: boolean;
     };
   };
+  permissions?: UserScopes[];
   theme?: 'light' | 'dark' | null;
   teams?: string[];
 }
@@ -27,6 +35,7 @@ export interface IUser {
       transport?: boolean;
     };
   };
+  permissions?: UserScopes[];
   theme?: 'light' | 'dark' | null;
   teams?: string[];
 }

--- a/src/services/firebase/server/db/index.ts
+++ b/src/services/firebase/server/db/index.ts
@@ -14,6 +14,7 @@ import { normaliseObjectKeysToArray } from '@/utils/normaliseObjectKeysToArray';
 import { type PassedHeaders } from '../serverApp';
 import { get, update } from './operations';
 import { getUser } from '../auth';
+import { checkCanEditConfig } from '../permissions';
 
 const SHORT_CACHE = 60 * 60; // one hour
 const LONG_CACHE = 60 * 60 * 24 * 7; // one week
@@ -122,10 +123,7 @@ export const pushConfig = async (
   try {
     const user = await getUser(headers);
 
-    if (
-      !user.currentUser?.isAdmin &&
-      !Object.values(user.currentUser?.scopes?.config || {}).some(Boolean)
-    ) {
+    if (!checkCanEditConfig(user.currentUser?.permissions)) {
       throw new Error(`Missing permissions for ${user.currentUser?.email}`);
     }
 

--- a/src/services/firebase/server/permissions.ts
+++ b/src/services/firebase/server/permissions.ts
@@ -6,6 +6,20 @@ export const permissions = [
   'admin',
 ] as const;
 
-export const checkCanEditRiscossi = (userPermissions?: string[]) => {
-  return userPermissions?.some((permission) => permission === 'write/riscossi');
-};
+const checkForPermission =
+  (permissionToCheck: string) => (userPermissions?: string[]) => {
+    return !!userPermissions?.some(
+      (permission) => permission === permissionToCheck
+    );
+  };
+
+export const checkIsAdmin = checkForPermission('admin');
+
+const withIsAdmin =
+  (additionalCheck: ReturnType<typeof checkForPermission>) =>
+  (permissions?: string[]) =>
+    checkIsAdmin() || additionalCheck(permissions);
+
+export const checkCanEditRiscossi = withIsAdmin(
+  checkForPermission('write/riscossi')
+);

--- a/src/services/firebase/server/permissions.ts
+++ b/src/services/firebase/server/permissions.ts
@@ -6,8 +6,10 @@ export const permissions = [
   'admin',
 ] as const;
 
+type Permission = (typeof permissions)[number];
+
 const checkForPermission =
-  (permissionToCheck: string) => (userPermissions?: string[]) => {
+  (permissionToCheck: Permission) => (userPermissions?: Permission[]) => {
     return !!userPermissions?.some(
       (permission) => permission === permissionToCheck
     );
@@ -17,9 +19,15 @@ export const checkIsAdmin = checkForPermission('admin');
 
 const withIsAdmin =
   (additionalCheck: ReturnType<typeof checkForPermission>) =>
-  (permissions?: string[]) =>
-    checkIsAdmin() || additionalCheck(permissions);
+  (permissions?: Permission[]) =>
+    checkIsAdmin(permissions) || additionalCheck(permissions);
 
 export const checkCanEditRiscossi = withIsAdmin(
   checkForPermission('write/riscossi')
 );
+
+export const checkCanEditConfig = withIsAdmin(
+  checkForPermission('write/config')
+);
+
+export const checkCanEditGMB = withIsAdmin(checkForPermission('write/gmb'));

--- a/src/services/firebase/server/permissions.ts
+++ b/src/services/firebase/server/permissions.ts
@@ -1,0 +1,11 @@
+export const permissions = [
+  'read/riscossi',
+  'write/riscossi',
+  'write/gmb',
+  'write/config',
+  'admin',
+] as const;
+
+export const checkCanEditRiscossi = (userPermissions?: string[]) => {
+  return userPermissions?.some((permission) => permission === 'write/riscossi');
+};

--- a/src/services/firebase/validator.ts
+++ b/src/services/firebase/validator.ts
@@ -6,16 +6,6 @@ export const UserSchema = z.object({
   cognome: z.string(),
   email: z.string(),
   isAdmin: z.boolean(),
-  scopes: z.optional(
-    z.object({
-      gmb: z.optional(z.boolean()),
-      config: z.optional(
-        z.object({
-          transport: z.optional(z.boolean()),
-        })
-      ),
-    })
-  ),
   permissions: z.optional(z.array(z.enum(permissions))),
   theme: z.optional(z.nullable(z.enum(['light', 'dark']))),
   teams: z.optional(z.array(z.string())),

--- a/src/services/firebase/validator.ts
+++ b/src/services/firebase/validator.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { permissions } from './server/permissions';
 
 export const UserSchema = z.object({
   nome: z.string(),
@@ -15,6 +16,7 @@ export const UserSchema = z.object({
       ),
     })
   ),
+  permissions: z.optional(z.array(z.enum(permissions))),
   theme: z.optional(z.nullable(z.enum(['light', 'dark']))),
   teams: z.optional(z.array(z.string())),
 });


### PR DESCRIPTION
This PR updates the app to use the new permission field on user, so that access can be controlled in a more fine-tuned way.

## Changes

- feat(user): add permissions
- chore(permissions): swap to curry function
- chore(admin): switch to new is admin
- chore(admin): switch to check config
- chore(google): switch to check gmb scope
- chore(nav): switch to check permissions
- chore(maps): switch to check permissions
- chore(db): remove scopes
- feat(nav): add riscossi